### PR TITLE
feat: Added monit compatibility with amazon linux

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -85,6 +85,12 @@ default['defaults']['worker']['adapter'] = 'null'
 default['defaults']['worker']['process_count'] = 2
 default['defaults']['worker']['syslog'] = true
 
+default['monit']['basedir'] = if platform?('centos', 'redhat', 'fedora', 'amazon')
+                                '/etc/monit.d'
+                              else
+                                '/etc/monit/conf.d'
+                              end
+
 ## sidekiq
 
 default['defaults']['worker']['config'] = { 'concurrency' => 5, 'verbose' => false, 'queues' => ['default'] }

--- a/libraries/drivers_worker_sidekiq.rb
+++ b/libraries/drivers_worker_sidekiq.rb
@@ -43,7 +43,7 @@ module Drivers
         output = out
         env = environment
 
-        context.template File.join('/', 'etc', 'monit', 'conf.d', "sidekiq_#{app_shortname}.monitrc") do
+        context.template File.join(node['monit']['basedir'], "sidekiq_#{app_shortname}.monitrc") do
           mode '0640'
           source 'sidekiq.monitrc.erb'
           variables application: app_shortname, out: output, deploy_to: deploy_to, environment: env


### PR DESCRIPTION
Enabling workers on amazon linux fails due to monit paths. Add configurable monit dirs and default based on platform.