### PR TITLE
Layer switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ Configuration parameters for the ruby application server. Currently only
 
 * `app['appserver']['adapter']`
   * **Default:** `unicorn`
-  * **Supported values:** `unicorn`
+  * **Supported values:** `unicorn`, `null`
   * Server on the application side, which will receive requests from webserver
-    in front.
+    in front. `null` means no appserver enabled.
 * [`app['appserver']['accept_filter']`](https://unicorn.bogomips.org/Unicorn/Configurator.html#method-i-listen)
   * **Default:** `httpready`
 * [`app['appserver']['backlog']`](https://unicorn.bogomips.org/Unicorn/Configurator.html#method-i-listen)
@@ -185,9 +185,9 @@ Currently only nginx is supported.
 
 * `app['webserver']['adapter']`
   * **Default:** `nginx`
-  * **Supported values:** `nginx`
+  * **Supported values:** `nginx`, `null`
   * Webserver in front of the instance. It runs on port 80,
-    and receives all requests from Load Balancer/Internet.
+    and receives all requests from Load Balancer/Internet. `null` means no webserver enabled.
 * `app['webserver']['build_type']`
   * **Supported values:** `default` or `source`
   * **Default:** `default`

--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ Currently only nginx is supported.
   * **Default:** `nginx`
   * **Supported values:** `nginx`, `null`
   * Webserver in front of the instance. It runs on port 80,
-    and receives all requests from Load Balancer/Internet. `null` means no webserver enabled.
+    and receives all requests from Load Balancer/Internet.
+    `null` means no webserver enabled.
 * `app['webserver']['build_type']`
   * **Supported values:** `default` or `source`
   * **Default:** `default`

--- a/libraries/drivers_appserver_null.rb
+++ b/libraries/drivers_appserver_null.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Drivers
+  module Appserver
+    class Null < Drivers::Appserver::Base
+      adapter :null
+      allowed_engines :null
+      output filter: []
+    end
+  end
+end

--- a/libraries/drivers_webserver_null.rb
+++ b/libraries/drivers_webserver_null.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Drivers
+  module Webserver
+    class Null < Drivers::Webserver::Base
+      adapter :null
+      allowed_engines :null
+      output filter: []
+    end
+  end
+end

--- a/spec/unit/libraries/drivers_appserver_factory_spec.rb
+++ b/spec/unit/libraries/drivers_appserver_factory_spec.rb
@@ -15,4 +15,18 @@ describe Drivers::Appserver::Factory do
     appserver = described_class.build(aws_opsworks_app, node)
     expect(appserver).to be_instance_of(Drivers::Appserver::Unicorn)
   end
+
+  context 'when adapter is null' do
+    it 'returns a Null class' do
+      appserver = described_class.build(aws_opsworks_app, node(deploy:
+                                                                {
+                                                                  dummy_project: {
+                                                                    appserver: {
+                                                                      adapter: 'null'
+                                                                    }
+                                                                  }
+                                                                }))
+      expect(appserver).to be_instance_of(Drivers::Appserver::Null)
+    end
+  end
 end

--- a/spec/unit/libraries/drivers_appserver_null_spec.rb
+++ b/spec/unit/libraries/drivers_appserver_null_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Drivers::Appserver::Null do
+  it 'receives and exposes app and node' do
+    driver = described_class.new(aws_opsworks_app, node)
+
+    expect(driver.app).to eq aws_opsworks_app
+    expect(driver.node).to eq node
+    expect(driver.options).to eq({})
+  end
+
+  it 'returns proper out data' do
+    expect(described_class.new(aws_opsworks_app, node).out).to eq({})
+  end
+end

--- a/spec/unit/libraries/drivers_webserver_factory_spec.rb
+++ b/spec/unit/libraries/drivers_webserver_factory_spec.rb
@@ -15,4 +15,18 @@ describe Drivers::Webserver::Factory do
     webserver = described_class.build(aws_opsworks_app, node)
     expect(webserver).to be_instance_of(Drivers::Webserver::Nginx)
   end
+
+  context 'when adapter is null' do
+    it 'returns a Null class' do
+      webserver = described_class.build(aws_opsworks_app, node(deploy:
+                                                                {
+                                                                  dummy_project: {
+                                                                    webserver: {
+                                                                      adapter: 'null'
+                                                                    }
+                                                                  }
+                                                                }))
+      expect(webserver).to be_instance_of(Drivers::Webserver::Null)
+    end
+  end
 end

--- a/spec/unit/libraries/drivers_webserver_null_spec.rb
+++ b/spec/unit/libraries/drivers_webserver_null_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Drivers::Webserver::Null do
+  it 'receives and exposes app and node' do
+    driver = described_class.new(aws_opsworks_app, node)
+
+    expect(driver.app).to eq aws_opsworks_app
+    expect(driver.node).to eq node
+    expect(driver.options).to eq({})
+  end
+
+  it 'returns proper out data' do
+    expect(described_class.new(aws_opsworks_app, node).out).to eq({})
+  end
+end


### PR DESCRIPTION
Adding null object for appserver and webserver adapters. Customize instances on a worker layer vs an appserver layer.