### PR TITLE
fix: specify bundle path on bundle install

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -60,7 +60,7 @@ end
 
 def perform_bundle_install(release_path)
   execute 'bundle_install' do
-    command 'bundle install --deployment --without development test'
+    command '/usr/local/bin/bundle install --deployment --without development test'
     cwd release_path
   end
 end


### PR DESCRIPTION
didn't know how to write a test for this, but it's super simple.

related to issue https://github.com/ajgon/opsworks_ruby/issues/31