### PR TITLE
Caching bundle installs to speed up deployments

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -58,9 +58,11 @@ def every_enabled_rds
   end
 end
 
-def perform_bundle_install(release_path)
+def perform_bundle_install(shared_path)
+  bundle_path = "#{shared_path}/vendor/bundle"
+
   execute 'bundle_install' do
-    command '/usr/local/bin/bundle install --deployment --without development test'
+    command "/usr/local/bin/bundle install --deployment --without development test --path #{bundle_path}"
     cwd release_path
   end
 end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -13,6 +13,7 @@ every_enabled_application do |application, _deploy|
   create_deploy_dir(application, File.join('shared', 'pids'))
   create_deploy_dir(application, File.join('shared', 'scripts'))
   create_deploy_dir(application, File.join('shared', 'sockets'))
+  create_deploy_dir(application, File.join('shared', 'vendor/bundle'))
 
   databases = []
   every_enabled_rds do |rds|

--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -52,7 +52,7 @@ every_enabled_application do |application, deploy|
     migration_command(framework.out[:migration_command])
     migrate framework.out[:migrate]
     before_migrate do
-      perform_bundle_install(release_path)
+      perform_bundle_install(shared_path)
 
       fire_hook(:deploy_before_migrate, context: self,
                                         items: databases + [scm, framework, appserver, worker, webserver])
@@ -61,7 +61,7 @@ every_enabled_application do |application, deploy|
     end
 
     before_symlink do
-      perform_bundle_install(release_path) unless framework.out[:migrate]
+      perform_bundle_install(shared_path) unless framework.out[:migrate]
 
       fire_hook(:deploy_before_symlink, context: self,
                                         items: databases + [scm, framework, appserver, worker, webserver])

--- a/spec/unit/recipes/configure_spec.rb
+++ b/spec/unit/recipes/configure_spec.rb
@@ -48,6 +48,10 @@ describe 'opsworks_ruby::configure' do
     it 'creates shared/sockets' do
       expect(chef_run).to create_directory("/srv/www/#{aws_opsworks_app['shortname']}/shared/sockets")
     end
+
+    it 'creates shared/vendor/bundle' do
+      expect(chef_run).to create_directory("/srv/www/#{aws_opsworks_app['shortname']}/shared/vendor/bundle")
+    end
   end
 
   context 'Postgresql + Git + Unicorn + Nginx + Sidekiq' do


### PR DESCRIPTION
Gems are currently being installed in the release path. When a new release is created, all the gems must be installed again. By caching the gems in the shared folder we can speed up the deployments considerably.