### PR TITLE
Add Aurora as allowed engine for MySQL driver

### DIFF
--- a/libraries/drivers_db_mysql.rb
+++ b/libraries/drivers_db_mysql.rb
@@ -3,7 +3,7 @@ module Drivers
   module Db
     class Mysql < Base
       adapter :mysql2
-      allowed_engines :mysql, :mysql2, :mariadb
+      allowed_engines :mysql, :mysql2, :mariadb, :aurora
       packages debian: 'libmysqlclient-dev', rhel: 'mysql-devel'
     end
   end

--- a/libraries/drivers_worker_sidekiq.rb
+++ b/libraries/drivers_worker_sidekiq.rb
@@ -12,6 +12,10 @@ module Drivers
         add_worker_monit
       end
 
+      def before_deploy
+        quiet_sidekiq
+      end
+
       def after_deploy
         restart_monit
       end
@@ -30,6 +34,15 @@ module Drivers
             source 'sidekiq.conf.yml.erb'
             variables config: config
           end
+        end
+      end
+
+      def quiet_sidekiq
+        deploy_to = deploy_dir(app)
+
+        (1..process_count).each do |process_number|
+          pid_file = "#{deploy_to}/shared/pids/sidekiq_#{process_number}.pid"
+          execute "/bin/su - #{node['deployer']['user']} -c 'kill -s USR1 `cat #{pid_file}`'"
         end
       end
 


### PR DESCRIPTION
AWS Aurora is backwards compatible with MySQL.  Aurora must be included in the driver because the factory favors the rds engine option over the database adapter from custom JSON

https://github.com/ajgon/opsworks_ruby/blob/397c89db1bc5d65333031d88a9617c7ba2e4669f/libraries/drivers_db_factory.rb#L15-L16