### PR TITLE
Add aurora as allowed engine for mysql2 adapter

### DIFF
--- a/libraries/drivers_db_mysql.rb
+++ b/libraries/drivers_db_mysql.rb
@@ -3,7 +3,7 @@ module Drivers
   module Db
     class Mysql < Base
       adapter :mysql2
-      allowed_engines :mysql, :mysql2, :mariadb
+      allowed_engines :mysql, :mysql2, :mariadb, :aurora
       packages debian: 'libmysqlclient-dev', rhel: 'mysql-devel'
     end
   end


### PR DESCRIPTION
Aurora is backwards compatible with MySQL