### PR TITLE
Allow deploy_before_restart on null appserver

### DIFF
--- a/libraries/drivers_appserver_null.rb
+++ b/libraries/drivers_appserver_null.rb
@@ -8,7 +8,6 @@ module Drivers
 
       def configure
       end
-      alias deploy_before_restart configure
       alias after_deploy configure
       alias after_undeploy configure
     end


### PR DESCRIPTION
This ensures the dotenv/application.yml options are still considered.  Useful for process servers that don't need an app server.