### PR TITLE
fix: Bump faraday middleware version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       ffi (>= 1.3.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.11.0)
+    faraday_middleware (0.11.0.1)
       faraday (>= 0.7.4, < 1.0)
     fasterer (0.3.2)
       colorize (~> 0.7)
@@ -349,4 +349,4 @@ DEPENDENCIES
   travis
 
 BUNDLED WITH
-   1.13.7
+   1.14.3


### PR DESCRIPTION
Per https://github.com/lostisland/faraday_middleware/issues/152, bundler
started reporting that 0.11.0 could not be installed due to a checksum
mismatch. To remedy the issue, the faraday middleware team has released
a patch version to allow users to bundle install from scratch again.

I am unsure as to whether or not this project prefers 1.13.17 for
bundler, or always the latest release but I am including the change here
as it is relevant when hitting this issue.

No breaking changes should be introduced here.