### PR TITLE
Replace ruby-ng with rvm

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@
 # ruby
 
 default['build-essential']['compile_time'] = true
-default['ruby-ng']['ruby_version'] = node['ruby'].try(:[], 'version') || '2.4'
+default['rvm']['default_ruby'] = node['ruby'].try(:[], 'version') || '2.4.0'
 default['nginx']['source']['modules'] = %w(
   nginx::http_ssl_module nginx::http_realip_module nginx::http_gzip_static_module nginx::headers_more_module
   nginx::http_stub_status_module

--- a/docs/source/attributes.rst
+++ b/docs/source/attributes.rst
@@ -34,11 +34,11 @@ convention).
      of an application, not included in this list - it will be skipped, as this list
      takes precedence over anything else.
 
--  ``node['ruby-ng']['ruby_version']``
+-  ``node['rvm']['default_ruby']``
 
   -  **Type:** string
-  -  **Default:** ``2.4``
-  -  Sets the Ruby version used through the system. See `ruby-ng cookbook documentation`_
+  -  **Default:** ``2.4.0``
+  -  Sets the Ruby version used through the system. See `rvm cookbook documentation`_
      for more details
 
 
@@ -495,7 +495,7 @@ resque
   -  **Default:** ``*``
   -  Array of queues which should be processed by resque
 
-.. _ruby-ng cookbook documentation: https://supermarket.chef.io/cookbooks/ruby-ng
+.. _rvm cookbook documentation: https://supermarket.chef.io/cookbooks/rvm
 .. _figaro: https://github.com/laserlemon/figaro
 .. _dotenv: https://github.com/bkeepers/dotenv
 .. |app['appserver']['backlog']| replace:: ``app['appserver']['backlog']``

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -5,7 +5,7 @@ Cookbooks
 ---------
 
 -  `deployer`_
--  `ruby-ng`_
+-  `rvm (~> 0.9)`_
 -  `chef_nginx`_
 
 Platform
@@ -22,5 +22,5 @@ This cookbook was tested on the following OpsWorks platforms:
 In addition, all recent Debian family distrubutions are assumed to work.
 
 .. _deployer: https://supermarket.chef.io/cookbooks/deployer
-.. _ruby-ng: https://supermarket.chef.io/cookbooks/ruby-ng
+.. _rvm: https://supermarket.chef.io/cookbooks/rvm
 .. _nginx (~> 2.7): https://supermarket.chef.io/cookbooks/nginx

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '1.3.0'
 
 depends 'deployer'
-depends 'ruby-ng'
+depends 'rvm', '~> 0.9'
 depends 'chef_nginx'
 
 supports 'amazon', '>= 2015.03'

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -8,14 +8,8 @@ prepare_recipe
 
 # Ruby and bundler
 include_recipe 'deployer'
-if node['platform_family'] == 'debian'
-  include_recipe 'ruby-ng::dev'
-else
-  ruby_pkg_version = node['ruby-ng']['ruby_version'].split('.')[0..1]
-  package "ruby#{ruby_pkg_version.join('')}"
-  package "ruby#{ruby_pkg_version.join('')}-devel"
-  execute "/usr/sbin/alternatives --set ruby /usr/bin/ruby#{ruby_pkg_version.join('.')}"
-end
+include_recipe 'rvm::default'
+include_recipe 'rvm::system'
 
 apt_repository 'apache2' do
   uri 'http://ppa.launchpad.net/ondrej/apache2/ubuntu'
@@ -26,14 +20,13 @@ apt_repository 'apache2' do
   only_if { node['platform'] == 'ubuntu' }
 end
 
-gem_package 'bundler'
 if node['platform_family'] == 'debian'
   link '/usr/local/bin/bundle' do
-    to '/usr/bin/bundle'
+    to "/usr/local/rvm/wrappers/ruby-#{node['rvm']['default_ruby']}@global/bundle"
   end
 else
   link '/usr/local/bin/bundle' do
-    to '/usr/local/bin/bundler'
+    to "/usr/local/rvm/wrappers/#{node['rvm']['default_ruby']}@global/bundler"
   end
 end
 


### PR DESCRIPTION
I believe this constitutes a major version change, which I have not included.  

There is a potential issue, where If you don't specify ruby versions with patch number it will break the `/usr/bin/local/bundle/` symlink.  I've updated the default attributes to reflect this.