### PR TITLE
feat(framework): Allow increased timeout during deploy

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,7 +9,7 @@ default['nginx']['source']['modules'] = %w(
   nginx::http_stub_status_module
 )
 
-default['deploy']['timeout'] = 600
+default['deploy']['timeout'] = nil
 
 # global
 default['defaults']['global']['environment'] = 'production'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,7 +9,7 @@ default['nginx']['source']['modules'] = %w(
   nginx::http_stub_status_module
 )
 
-default['deploy']['timeout'] = nil
+default['deploy']['timeout'] = 600
 
 # global
 default['defaults']['global']['environment'] = 'production'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,6 +9,8 @@ default['nginx']['source']['modules'] = %w(
   nginx::http_stub_status_module
 )
 
+default['deploy']['timeout'] = 600
+
 # global
 default['defaults']['global']['environment'] = 'production'
 default['defaults']['global']['symlinks'] = {

--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -96,6 +96,8 @@ every_enabled_application do |application|
 
       run_callback_from_file(File.join(release_path, 'deploy', 'after_restart.rb'))
     end
+
+    timeout node['deploy']['timeout']
   end
 
   fire_hook(:after_deploy, items: databases + [scm, framework, appserver, worker, webserver])


### PR DESCRIPTION
Allow increased timeout on deploy.  Specific use case is for migrations that take a long time.

Please, squash and merge.