### PR TITLE
feat(webserver): server_tokens off on Nginx

### DIFF
--- a/templates/default/appserver.nginx.conf.erb
+++ b/templates/default/appserver.nginx.conf.erb
@@ -10,6 +10,8 @@ server {
 
   root <%= File.join(@deploy_dir, 'current', 'public') %>;
 
+  server_tokens off;
+
   client_max_body_size <%= @out[:client_max_body_size] || '1m' %>;
   client_body_timeout <%= @out[:client_body_timeout] || '12' %>;
   client_header_timeout <%= @out[:client_header_timeout] || '12' %>;
@@ -102,6 +104,8 @@ server {
   <% end -%>
 
   root <%= File.join(@deploy_dir, 'current', 'public') %>;
+
+  server_tokens off;
 
   client_max_body_size <%= @out[:client_max_body_size] || '1m' %>;
   client_body_timeout <%= @out[:client_body_timeout] || '12' %>;


### PR DESCRIPTION
I think that it is better to hide version info.