### PR TITLE
feat(global): support per-application deploy directory

### DIFF
--- a/.fasterer.yml
+++ b/.fasterer.yml
@@ -1,0 +1,9 @@
+---
+# Fasterer mistakenly flags the warning that
+# "Hash#keys.each is slower than Hash#each_key" on the Chef
+# node object (which is not a Hash). Because Fasterer only
+# has two ways to disable its analyzer (ignore a file entirely
+# or ignore a speedup entirely), we pick the lesser of two
+# evils and disable the keys_each_vs_each_key test :-/
+speedups:
+ keys_each_vs_each_key: false

--- a/docs/source/attributes.rst
+++ b/docs/source/attributes.rst
@@ -58,6 +58,15 @@ Global parameters apply to the whole application, and can be used by any section
   -  Sets the “deploy environment” for all the app-related (for example ``RAILS_ENV``
      in Rails) actions in the project (server, worker, etc.)
 
+-  ``app['global']['deploy_dir']``
+
+  -  **Type:** string
+  -  **Default:** ``/srv/www/app_name``
+  -  Determines where the application will be deployed.
+  -  Note that if you override this setting, you'll typically want to include the short_name
+     in the setting. In other words, this setting doesn't override the ``/srv/www`` base
+     directory defafult; it overrides the application-specific ``/srv/www/app_name`` default.
+
 - ``app['global']['symlinks']``
 
   -  **Type:** key-value

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -61,7 +61,7 @@ def create_deploy_dir(application, subdir = '/')
 end
 
 def deploy_dir(application)
-  File.join('/', 'srv', 'www', application['shortname'])
+  globals('deploy_dir', application['shortname']) || ::File.join('/', 'srv', 'www', application['shortname'])
 end
 
 def every_enabled_application


### PR DESCRIPTION
Some Opsworks users deploy their apps on custom AMIs with strict
partitioning schemes and disk space limitations. For these users
the default deploy directory /srv/www is not always a good choice.

This patch allows users to override the deploy directory at the
application level by specifying the attribute

`node['deploy'][shortname]['global']['deploy_dir']`

The default value for the app-specific deploy directory continues to be
/srv/www/shortname.

Fixes #95