### PR TITLE
Support arbitrary customization of webserver site configuration

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -141,5 +141,7 @@ suites:
             adapter: 'unicorn'
           webserver:
             adapter: 'apache2'
+            port: 8080
+            ssl_port: 8443
       'ruby-ng':
         ruby_version: '2.3'

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -124,3 +124,22 @@ suites:
             adapter: 'null'
           webserver:
             adapter: 'null'
+  - name: maximum_override
+    data_bags_path: "test/integration/data_bags/maximum_override"
+    run_list:
+      - recipe[opsworks_ruby::setup]
+      - recipe[opsworks_ruby::deploy]
+    attributes:
+      deploy:
+        other_project:
+          database:
+            adapter: 'null'
+          framework:
+            adapter: 'rails'
+            assets_precompilation_command: '/bin/true'
+          appserver:
+            adapter: 'unicorn'
+          webserver:
+            adapter: 'apache2'
+      'ruby-ng':
+        ruby_version: '2.3'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -69,6 +69,8 @@ default['defaults']['appserver']['tries'] = 5
 ## common
 
 default['defaults']['webserver']['adapter'] = 'nginx'
+default['defaults']['webserver']['port'] = 80
+default['defaults']['webserver']['ssl_port'] = 443
 default['defaults']['webserver']['ssl_for_legacy_browsers'] = false
 default['defaults']['webserver']['extra_config'] = ''
 default['defaults']['webserver']['extra_config_ssl'] = ''

--- a/docs/source/attributes.rst
+++ b/docs/source/attributes.rst
@@ -367,9 +367,9 @@ webserver
 
   -  **Default:** ``nginx``
   -  **Supported values:** ``apache2``, ``nginx``, ``null``
-  -  Webserver in front of the instance. It runs on port 80,
-     and receives all requests from Load Balancer/Internet.
-     ``null`` means no webserver enabled.
+  -  Webserver in front of the instance. It runs on port 80 by default
+     (see ``app['webserver']['port']``), and receives all requests from the
+     Load Balancer/Internet. ``null`` means no webserver enabled.
 
 -  ``app['webserver']['dhparams']``
 
@@ -392,19 +392,54 @@ webserver
      Android < 2.2) wouldn’t work with this configuration very well. If your
      application needs a support for those browsers, set this parameter to ``true``.
 
+-  ``app['webserver']['port']``
+
+  -  **Default** ``80``
+  -  The port on which the webserver should listen for HTTP requests.
+
+-  ``app['webserver']['ssl_port']``
+
+  -  **Default** ``443``
+  -  The port on which the webserver should listen for HTTPs requests, if
+     SSL requests are enabled. Note that SSL itself is controlled by the
+     ``app['enable_ssl']`` setting in Opsworks.
+
+-  ``app['webserver']['site_config_template']``
+
+  -  **Default** ``appserver.apache2.conf.erb`` or ``appserver.nginx.conf.erb``
+  -  The name of the cookbook template that should be used to generate per-app
+     configuration stanzas (known as a "site" in apache and nginx configuration
+     parlance). Useful in situations where inserting an ``extra_config`` text
+     section doesn't provide enough flexibility to customize your per-app
+     webserver configuration stanza to your liking.
+  -  Note that when you use a custom site configuration template, you can
+     also choose to define ``extra_config`` as any data structure (e.g., Hash
+     or even nested Hash) to be interpreted by your custom template. This
+     provides somewhat unlimited flexibility to configure the webserver app
+     configuration however you see fit.
+
+-  ``app['webserver']['site_config_template_cookbook']``
+
+  -  **Default** ``opsworks_ruby``
+  -  The name of the cookbook in which the site configuration template can be
+     found. If you override ``app['webserver']['site_config_template']`` to
+     use a site configuration template from your own cookbook, you'll need to
+     override this setting as well to ensure that the opsworks_ruby cookbook
+     looks for the specified template in your cookbook.
+
 apache
 ^^^^^^
 
 -  ``app['webserver']['extra_config']``
 
   -  Raw Apache2 configuration, which will be inserted into ``<Virtualhost *:80>``
-     section of the application.
+     (or other port, if specified) section of the application.
 
 -  ``app['webserver']['extra_config_ssl']``
 
   -  Raw Apache2 configuration, which will be inserted into ``<Virtualhost *:443>``
-     section of the application. If set to ``true``, the ``extra_config``
-     will be copied.
+     (or other port, if specified for SSL) section of the application. If set to
+     ``true``, the ``extra_config`` will be copied.
 
 -  |app['webserver']['limit_request_body']|_
 

--- a/docs/source/attributes.rst
+++ b/docs/source/attributes.rst
@@ -117,9 +117,11 @@ database
 
 -  ``app['database']['adapter']``
 
-  -  **Supported values:** ``mariadb``, ``mysql``, ``postgresql``, ``sqlite3``
+  -  **Supported values:** ``mariadb``, ``mysql``, ``postgresql``, ``sqlite3``, ``null``
   -  **Default:** ``sqlite3``
-  -  ActiveRecord adapter which will be used for database connection.
+  -  ActiveRecord adapter which will be used for database connection. ``null`` means
+     that no database will be configured, and is currently only tested with the ``rails``
+     framework.
 
 -  ``app['database']['username']``
 

--- a/libraries/drivers_db_base.rb
+++ b/libraries/drivers_db_base.rb
@@ -38,6 +38,14 @@ module Drivers
           app['data_sources'].first['arn'] == options[:rds]['rds_db_instance_arn']
       end
 
+      def can_migrate?
+        true
+      end
+
+      def url(_deploy_dir)
+        "#{out[:adapter]}://#{out[:username]}:#{out[:password]}@#{out[:host]}/#{out[:database]}"
+      end
+
       protected
 
       def app_engine

--- a/libraries/drivers_db_null.rb
+++ b/libraries/drivers_db_null.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Drivers
+  module Db
+    class Null < Base
+      adapter :null
+      allowed_engines :null
+      output filter: []
+      defaults username: nil, password: nil, host: nil, database: nil
+
+      def can_migrate?
+        false
+      end
+    end
+  end
+end

--- a/libraries/drivers_db_sqlite.rb
+++ b/libraries/drivers_db_sqlite.rb
@@ -12,6 +12,10 @@ module Drivers
         output[:database] ||= 'db/data.sqlite3'
         handle_output(output)
       end
+
+      def url(deploy_dir)
+        "sqlite://#{deploy_dir}/shared/#{out[:database]}"
+      end
     end
   end
 end

--- a/libraries/drivers_framework_rails.rb
+++ b/libraries/drivers_framework_rails.rb
@@ -9,7 +9,7 @@ module Drivers
         migrate migration_command deploy_environment assets_precompile assets_precompilation_command
         envs_in_console
       ]
-      packages debian: 'zlib1g-dev', rhel: 'zlib-devel'
+      packages debian: %w[libxml2-dev tzdata zlib1g-dev], rhel: %w[libxml2-devel tzdata zlib-devel]
       log_paths lambda { |context|
         File.join(context.send(:deploy_dir, context.app), 'shared', 'log', '*.log')
       }
@@ -34,7 +34,7 @@ module Drivers
       private
 
       def database_yml(db)
-        return unless db.applicable_for_configuration?
+        return unless db.applicable_for_configuration? && db.can_migrate?
 
         database = db.out
         deploy_environment = deploy_env

--- a/libraries/drivers_webserver_apache2.rb
+++ b/libraries/drivers_webserver_apache2.rb
@@ -8,7 +8,7 @@ module Drivers
       packages debian: 'apache2', rhel: %w[httpd24 mod24_ssl]
       output filter: %i[
         dhparams keepalive_timeout limit_request_body log_dir log_level proxy_timeout
-        ssl_for_legacy_browsers extra_config extra_config_ssl
+        ssl_for_legacy_browsers extra_config extra_config_ssl port ssl_port
       ]
       notifies :deploy,
                action: :restart, resource: { debian: 'service[apache2]', rhel: 'service[httpd]' }, timer: :delayed

--- a/libraries/drivers_webserver_base.rb
+++ b/libraries/drivers_webserver_base.rb
@@ -80,12 +80,16 @@ module Drivers
         opts = { application: app, deploy_dir: deploy_dir(app), out: out, conf_dir: conf_dir, adapter: adapter,
                  name: Drivers::Appserver::Factory.build(context, app).adapter }
         return unless Drivers::Appserver::Base.adapters.include?(opts[:name])
+        generate_appserver_config(opts, site_config_template, site_config_template_cookbook)
+      end
 
+      def generate_appserver_config(opts, source_template, source_cookbook)
         context.template "#{opts[:conf_dir]}/sites-available/#{app['shortname']}.conf" do
           owner 'root'
           group 'root'
           mode '0644'
-          source "appserver.#{opts[:adapter]}.conf.erb"
+          source source_template.to_s
+          cookbook source_cookbook.to_s
           variables opts
         end
       end
@@ -97,6 +101,18 @@ module Drivers
         context.link "#{conf_path}/sites-enabled/#{application['shortname']}.conf" do
           to "#{conf_path}/sites-available/#{application['shortname']}.conf"
         end
+      end
+
+      def site_config_template
+        (node['deploy'][app['shortname']]['webserver'] || {})['site_config_template'] ||
+          node['defaults']['webserver']['site_config_template'] ||
+          "appserver.#{adapter}.conf.erb"
+      end
+
+      def site_config_template_cookbook
+        (node['deploy'][app['shortname']]['webserver'] || {})['site_config_template_cookbook'] ||
+          node['defaults']['webserver']['site_config_template_cookbook'] ||
+          context.cookbook_name
       end
     end
   end

--- a/libraries/drivers_webserver_nginx.rb
+++ b/libraries/drivers_webserver_nginx.rb
@@ -8,7 +8,7 @@ module Drivers
       output filter: %i[
         build_type client_body_timeout client_header_timeout client_max_body_size dhparams keepalive_timeout
         log_dir log_level proxy_read_timeout proxy_send_timeout send_timeout ssl_for_legacy_browsers
-        extra_config extra_config_ssl enable_upgrade_method
+        extra_config extra_config_ssl enable_upgrade_method port ssl_port
       ]
       notifies :deploy, action: :restart, resource: 'service[nginx]', timer: :delayed
       notifies :undeploy, action: :restart, resource: 'service[nginx]', timer: :delayed

--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -60,7 +60,7 @@ every_enabled_application do |application|
     end
 
     migration_command(framework.out[:migration_command]) if framework.out[:migration_command]
-    migrate framework.out[:migrate]
+    migrate framework.migrate?
     before_migrate do
       perform_bundle_install(shared_path, bundle_env)
 
@@ -72,7 +72,7 @@ every_enabled_application do |application|
     end
 
     before_symlink do
-      perform_bundle_install(shared_path, bundle_env) unless framework.out[:migrate]
+      perform_bundle_install(shared_path, bundle_env) unless framework.migrate?
 
       fire_hook(
         :deploy_before_symlink, context: self, items: databases + [scm, framework, appserver, worker, webserver]

--- a/templates/default/appserver.apache2.conf.erb
+++ b/templates/default/appserver.apache2.conf.erb
@@ -1,6 +1,10 @@
 <% upstream = "#{@name}_#{@application[:domains].first}".gsub(/[^a-zA-Z0-9]+/, '_') %>
 
-<VirtualHost *:80>
+<% unless @out[:port] == 80 %>
+Listen <%= @out[:port] %>
+<% end -%>
+
+<VirtualHost *:<%= @out[:port] %>>
   ServerName <%= node['hostname'] %>
   ServerAlias <%= @application[:domains].join(" ") %>
 
@@ -55,8 +59,12 @@
 </VirtualHost>
 
 <% if @application[:enable_ssl] %>
+<% unless @out[:ssl_port] == 443 %>
+Listen <%= @out[:ssl_port] %>
+<% end -%>
+
 SSLStaplingCache "shmcb:logs/stapling-cache(150000)"
-<VirtualHost *:443>
+<VirtualHost *:<%= @out[:ssl_port] %>>
   ServerName <%= node['hostname'] %>
   ServerAlias <%= @application[:domains].join(" ") %>
 

--- a/templates/default/appserver.nginx.conf.erb
+++ b/templates/default/appserver.nginx.conf.erb
@@ -3,7 +3,7 @@ upstream <%= @name %>_<%= @application[:domains].first %> {
 }
 
 server {
-  listen 80;
+  listen <%= @out[:port] %>;
   server_name <%= @application[:domains].join(" ") %> <%= node['hostname'] %>;
   access_log <%= @out[:log_dir] %>/<%= @application[:domains].first %>.access.log;
   error_log <%= @out[:log_dir] %>/<%= @application[:domains].first %>.error.log <%= @out[:log_level] %>;
@@ -68,7 +68,7 @@ server {
 
 <% if @application[:enable_ssl] %>
 server {
-  listen   443;
+  listen <%= @out[:ssl_port] %>;
   server_name <%= @application[:domains].join(" ") %> <%= node['hostname'] %>;
   access_log <%= @out[:log_dir] %>/<%= @application[:domains].first %>-ssl.access.log;
   error_log <%= @out[:log_dir] %>/<%= @application[:domains].first %>-ssl.error.log <%= @out[:log_level] %>;

--- a/test/integration/data_bags/maximum_override/aws_opsworks_app/other_project.json
+++ b/test/integration/data_bags/maximum_override/aws_opsworks_app/other_project.json
@@ -1,0 +1,34 @@
+{
+  "app_id": "3aef37c1-7e2b-4255-bbf1-03e06f07701a",
+  "app_source": {
+    "password": "3aa161d358a167204502",
+    "revision": "master",
+    "type": "git",
+    "url": "https://github.com/RapidRiverSoftware/dumber-app",
+    "user": "dummy"
+  },
+  "attributes": {
+    "auto_bundle_on_deploy": true,
+    "aws_flow_ruby_settings": {},
+    "document_root": "",
+    "rails_env": null
+  },
+  "data_sources": [],
+  "domains": [
+    "other-project.example.com",
+    "other_project"
+  ],
+  "enable_ssl": true,
+  "environment": {
+    "ENV_VAR1": "test"
+  },
+  "name": "Dummy app",
+  "shortname": "other_project",
+  "ssl_configuration": {
+    "certificate": "-----BEGIN CERTIFICATE-----\nMIICkzCCAfwCCQCs8PFrlPxmzTANBgkqhkiG9w0BAQUFADCBjTELMAkGA1UEBhMC\nVVMxEzARBgNVBAgTCkNhbGlmb3JuaWExGDAWBgNVBAcTD1NpbGxpY29uIFZhbGxl\neTEWMBQGA1UEChQNb3Bzd29ya3NfcnVieTEWMBQGA1UEAxQNKi5leGFtcGxlLmNv\nbTEfMB0GCSqGSIb3DQEJARYQaWdvckByemVnb2NraS5wbDAeFw0xNjEwMjUxMzU4\nNDVaFw0xNzEwMjUxMzU4NDVaMIGNMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2Fs\naWZvcm5pYTEYMBYGA1UEBxMPU2lsbGljb24gVmFsbGV5MRYwFAYDVQQKFA1vcHN3\nb3Jrc19ydWJ5MRYwFAYDVQQDFA0qLmV4YW1wbGUuY29tMR8wHQYJKoZIhvcNAQkB\nFhBpZ29yQHJ6ZWdvY2tpLnBsMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDF\nkSHFW+Vaffu/IHps5m5H/U+zeuIUuc/STWTzo82b+8Lv47n3jYB8Rx98Ti8lcPLW\nAIfRSo0pKry9vMYUNbzq+5bEoyfJWWnFgKlHwL5Znl2104Go9sjGHOcnggTFxoH+\n3GbBlM122h2aaxNDn3BLpvlCbfWRkyuZBJRYJ8BDAwIDAQABMA0GCSqGSIb3DQEB\nBQUAA4GBAJvYjvy/bK+8bFKt/EelhSWM/+/YWxQeH6WyKVkKCFu8SAcudtIUN0+b\nmgtpX8hLR7OfJ1QGHbj50USBvMcZcXPseSA9tl3uVsFeIHpVIJDzwcXd2UIklqa0\nTWWRQeP80euInTpyMZ3nygG48O00WGDV081UMS0mLUxAKVeLdUJA\n-----END CERTIFICATE-----\n",
+    "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQDFkSHFW+Vaffu/IHps5m5H/U+zeuIUuc/STWTzo82b+8Lv47n3\njYB8Rx98Ti8lcPLWAIfRSo0pKry9vMYUNbzq+5bEoyfJWWnFgKlHwL5Znl2104Go\n9sjGHOcnggTFxoH+3GbBlM122h2aaxNDn3BLpvlCbfWRkyuZBJRYJ8BDAwIDAQAB\nAoGAC5gWyUQ5U3QtP+wiAx4KvsLI2JmPhvPYlFjiYcHtIQhHSlis4zA0qBZsbJkR\n/zp/pbtmPQwI+K9/YAsh/LGionUEfNyM4m3tuvLY860AqTlD4fCFANvLEXX4ryGq\n4Jjy8Vsq8+Yf9+Ej2VaKBR2TJJxczdgeDii2t74f+Y44DeECQQD+aBRGl18yfk5Y\nkrSWA1vnG7Nnd1eh0WXN1wUVq1/wgt8P2Ejuwyf2KrKgYoUOBfSL+p9mwsO6cR4X\ns9YJTRKJAkEAxs3qM7YoM2xFuohcuMCzTb+7kpV5nahZc0NyipFtCUfKU0JAqgr5\nN5HTQ756s3pvoifkVNE0b14xpnj1Qmt2KwJBALWlCH0SjXUW+8eAEBJgGZlcjO7e\nJiKyyRZ8ZPQA5cJrHutISWK40uqPt/SOA2Rs2hur+W48t9WB+LOBwtvnPMkCQFyX\n84j6QmcQ+rkSYf0640hHENoI/IfNrTveIi8f5KT55uY4aV3JlqGnLbrTsNp/IBdq\ndRJ8DewA9ycOF01EN9kCQEJVMn/cgbTT4hNyte2ycyHxTSh1h5ImipV8khcopanV\naSxsp8mM4JwGSzWtfF9+EMVymZ2OsH7oSYfawzKjSGg=\n-----END RSA PRIVATE KEY-----\n"
+  },
+  "type": "other",
+  "deploy": true,
+  "id": "other_project"
+}

--- a/test/integration/maximum_override/serverspec/maximum_override_spec.rb
+++ b/test/integration/maximum_override/serverspec/maximum_override_spec.rb
@@ -69,6 +69,10 @@ describe 'opsworks_ruby::configure' do
       its(:content) { should include '<Proxy balancer://unicorn_other_project_example_com>' }
       its(:content) { should include 'SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH' }
       its(:content) { should include 'DocumentRoot /srv/www/other_project/current/public' }
+      its(:content) { should include 'Listen 8080' }
+      its(:content) { should include '<VirtualHost *:8080>' }
+      its(:content) { should include 'Listen 8443' }
+      its(:content) { should include '<VirtualHost *:8443>' }
     end
   end
 

--- a/test/integration/maximum_override/serverspec/maximum_override_spec.rb
+++ b/test/integration/maximum_override/serverspec/maximum_override_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'opsworks_ruby::setup' do
+  describe package('ruby2.3') do
+    it { should be_installed }
+  end
+
+  describe package('libsqlite3-dev') do
+    it { should_not be_installed }
+  end
+
+  describe package('git') do
+    it { should be_installed }
+  end
+
+  describe package('apache2') do
+    it { should be_installed }
+  end
+
+  describe package('redis-server') do
+    it { should_not be_installed }
+  end
+
+  describe file('/usr/local/bin/bundle') do
+    it { should be_symlink }
+  end
+end
+
+describe 'opsworks_ruby::configure' do
+  context 'webserver' do
+    describe file('/etc/logrotate.d/other_project-apache2-production') do
+      its(:content) do
+        should include '"/var/log/apache2/other-project.example.com.access.log" ' \
+                       '"/var/log/apache2/other-project.example.com.error.log" {'
+      end
+      its(:content) { should include '  daily' }
+      its(:content) { should include '  rotate 30' }
+      its(:content) { should include '  missingok' }
+      its(:content) { should include '  compress' }
+      its(:content) { should include '  delaycompress' }
+      its(:content) { should include '  notifempty' }
+      its(:content) { should include '  copytruncate' }
+      its(:content) { should include '  sharedscripts' }
+    end
+
+    describe file('/etc/apache2/ssl/other-project.example.com.key') do
+      its(:content) { should include '-----BEGIN RSA PRIVATE KEY-----' }
+    end
+
+    describe file('/etc/apache2/ssl/other-project.example.com.crt') do
+      its(:content) { should include '-----BEGIN CERTIFICATE-----' }
+    end
+
+    describe file('/etc/apache2/ssl/other-project.example.com.ca') do
+      it { should_not exist }
+    end
+
+    describe file('/etc/apache2/ssl/other-project.example.com.dhparams.pem') do
+      it { should_not exist }
+    end
+
+    describe file('/etc/apache2/sites-enabled/other_project.conf') do
+      it { should be_symlink }
+    end
+
+    describe file('/etc/apache2/sites-available/other_project.conf') do
+      its(:content) { should include '<Proxy balancer://unicorn_other_project_example_com>' }
+      its(:content) { should include 'SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH' }
+      its(:content) { should include 'DocumentRoot /srv/www/other_project/current/public' }
+    end
+  end
+
+  context 'appserver' do
+    describe file('/srv/www/other_project/shared/config/unicorn.conf') do
+      its(:content) { should include ':backlog => 1024' }
+      its(:content) { should include ':tries => 5' }
+      its(:content) { should include 'listen "127.0.0.1:3000"' }
+    end
+
+    describe file('/srv/www/other_project/shared/scripts/unicorn.service') do
+      its(:content) { should include 'ENV[\'ENV_VAR1\'] = "test"' }
+      its(:content) { should include 'ENV[\'HOME\'] = "/home/deploy"' }
+      its(:content) { should include 'ENV[\'USER\'] = "deploy"' }
+      its(:content) { should include 'PID_PATH="/srv/www/other_project/shared/pids/unicorn.pid"' }
+      its(:content) { should include 'def unicorn_running?' }
+    end
+  end
+
+  context 'framework' do
+    describe file('/etc/logrotate.d/other_project-rails-production') do
+      its(:content) { should include '"/srv/www/other_project/shared/log/*.log" {' }
+      its(:content) { should include '  daily' }
+      its(:content) { should include '  rotate 30' }
+      its(:content) { should include '  missingok' }
+      its(:content) { should include '  compress' }
+      its(:content) { should include '  delaycompress' }
+      its(:content) { should include '  notifempty' }
+      its(:content) { should include '  copytruncate' }
+      its(:content) { should include '  sharedscripts' }
+    end
+
+    describe file('/srv/www/other_project/shared/config/.env.production') do
+      it { should_not exist }
+    end
+  end
+end
+
+describe 'opsworks_ruby::deploy' do
+  context 'scm' do
+    describe file('/tmp/ssh-git-wrapper.sh') do
+      its(:content) { should include 'exec ssh -o UserKnownHostsFile=/dev/null' }
+    end
+
+    describe file('/srv/www/other_project/current/.git') do
+      it { should_not exist }
+    end
+  end
+
+  context 'webserver' do
+    describe service('apache2') do
+      it { should be_running }
+    end
+  end
+
+  context 'appserver' do
+    describe command('pgrep -f unicorn | tr \'\n\' \' \'') do
+      its(:stdout) { should match(/(?:[0-9]+ ){2}/) }
+    end
+  end
+
+  context 'framework' do
+    describe file('/srv/www/other_project/shared/config/database.yml') do
+      it { should_not exist }
+    end
+
+    describe file('/srv/www/other_project/current/config/database.yml') do
+      it { should be_symlink }
+    end
+  end
+end


### PR DESCRIPTION
Allow the user to deploy multiple applications on a single server,
each listening on a distinct port:

`app['webserver']['port']` and `app['webserver']['ssl_port']` (default
80 and 443, respectively), as well as the corresponding `global` values,
will allow the user to override the port that the application listens to
in Apache2 or nginx.

Allow user to override which template is used to generate Apache2 or
nginx per-app webserver configurations (aka "site configs"):

`app['webserver']['site_config_template']` and
`app['webserver']['site_config_template_cookbook']` (defaults are
`appserver.#{webserver}.conf.erb` and `opswork_ruby`, respectively), as
well as the corresponding `global` values, will allow the user to
specify which template (from which cookbook) should be used to render
the webserver site configuration.

Fixes #100 

TODO:
- [x] Write integration tests