### PR TITLE
feature(logrotate): pass script parameters into logrotate

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,7 @@ default['defaults']['global']['create_dirs_before_symlink'] =
 default['defaults']['global']['purge_before_symlink'] = %w[log tmp/cache tmp/pids public/system public/assets]
 default['defaults']['global']['rollback_on_error'] = true
 default['defaults']['global']['logrotate_rotate'] = 30
+default['defaults']['global']['logrotate_script_params'] = {}
 
 # database
 ## common

--- a/docs/source/attributes.rst
+++ b/docs/source/attributes.rst
@@ -95,6 +95,14 @@ Global parameters apply to the whole application, and can be used by any section
   -  **Default:** ``30``
   -  **Important Notice:** The parameter is in days
 
+- ``app['global']['logrotate_script_params']``
+
+  -  **Type:** key-value
+  -  **Default:** ``{}``
+  -  **Important Notice:** Any values for this parameter will be *merged* to the defaults
+  -  List of passable options can be found in the `logrotate man page`_.
+     For example ``{"postrotate": "echo 'hi'"}``
+
 database
 ~~~~~~~~
 
@@ -508,6 +516,7 @@ resque
   -  Array of queues which should be processed by resque
 
 .. _ruby-ng cookbook documentation: https://supermarket.chef.io/cookbooks/ruby-ng
+.. _logrotate man page: https://linux.die.net/man/8/logrotate
 .. _figaro: https://github.com/laserlemon/figaro
 .. _dotenv: https://github.com/bkeepers/dotenv
 .. |app['appserver']['backlog']| replace:: ``app['appserver']['backlog']``

--- a/libraries/drivers_dsl_logrotate.rb
+++ b/libraries/drivers_dsl_logrotate.rb
@@ -19,18 +19,22 @@ module Drivers
           (self.class.superclass.respond_to?(:log_paths) && self.class.superclass.log_paths)
       end
 
+      # rubocop:disable Metrics/MethodLength
       def configure_logrotate
         return if (log_paths || []).empty?
         lr_path = logrotate_log_paths
         lr_rotate = logrotate_rotate
+        lr_script_options = logrotate_script_params
 
         context.logrotate_app "#{app['shortname']}-#{adapter}-#{deploy_env}" do
           path lr_path
           frequency 'daily'
           rotate lr_rotate
+          lr_script_options.each_pair { |script_type, cmds| send(script_type, cmds) }
           options %w[missingok compress delaycompress notifempty copytruncate sharedscripts]
         end
       end
+      # rubocop:enable Metrics/MethodLength
 
       def logrotate_log_paths
         log_paths.map do |log_path|
@@ -42,6 +46,10 @@ module Drivers
 
       def logrotate_rotate
         globals(:logrotate_rotate, app['shortname'])
+      end
+
+      def logrotate_script_params
+        globals(:logrotate_script_params, app['shortname'])
       end
     end
   end


### PR DESCRIPTION
[issue #105 ](https://github.com/ajgon/opsworks_ruby/issues/105)
This gives the user the ability to add postscript, prescript, etc. Also, will throw a no method error if the option is invalid. This defaults to an empty hash.