### PR TITLE
fix(webserver): Only remove default enabled sites

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -179,5 +179,17 @@ suites:
             logrotate_template_owner: 'root'
             port: 8080
             ssl_port: 8443
+        yet_another_project:
+          appserver:
+            adapter: 'unicorn'
+          database:
+            adapter: 'null'
+          framework:
+            adapter: 'rails'
+            assets_precompilation_command: '/bin/true'
+            logrotate_name: 'dumberer-app-logrotate'
+          webserver:
+            adapter: 'apache2'
+            port: 8081
       'ruby-ng':
         ruby_version: '2.3'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -83,6 +83,9 @@ default['defaults']['webserver']['extra_config'] = ''
 default['defaults']['webserver']['extra_config_ssl'] = ''
 default['defaults']['webserver']['keepalive_timeout'] = '15'
 default['defaults']['webserver']['log_level'] = 'info'
+default['defaults']['webserver']['remove_default_sites'] = %w[
+  default default.conf 000-default 000-default.conf default-ssl default-ssl.conf
+]
 
 ## apache2
 

--- a/docs/source/attributes.rst
+++ b/docs/source/attributes.rst
@@ -41,6 +41,24 @@ convention).
   -  Sets the Ruby version used through the system. See `ruby-ng cookbook documentation`_
      for more details
 
+Cross-application attributes
+----------------------------
+
+These attributes can only be set at the server level; they cannot vary from
+application to application.
+
+webserver
+~~~~~~~~~
+
+-  ``node['defaults']['webserver']['remove_default_sites']``
+
+  -  **Type:** array
+  -  **Default:** ``%w[default default.conf 000-default 000-default.conf default-ssl default-ssl.conf]``
+  -  **Note**: Only applies to Apache2 webserver
+  -  A list of "default site" filenames that should be removed (if they exist) from
+     ``/etc/{httpd,apache2}/sites-enabled`` in order to disable any "default site"
+     provided by the OS-provided Apache2 package. Set this to ``nil`` or an empty
+     array (``[]``) if you want the default site to be enabled.
 
 Application attributes
 ----------------------

--- a/libraries/drivers_webserver_apache2.rb
+++ b/libraries/drivers_webserver_apache2.rb
@@ -70,11 +70,10 @@ module Drivers
 
       def remove_defaults
         conf_path = conf_dir
-
-        context.execute 'Remove default sites' do
-          command "find #{conf_path}/sites-enabled -maxdepth 1 -mindepth 1 -exec rm -rf {} \\;"
-          user 'root'
-          group 'root'
+        (node['defaults']['webserver']['remove_default_sites'] || []).each do |file|
+          context.file "#{conf_path}/sites-enabled/#{file}" do
+            action :delete
+          end
         end
       end
 

--- a/spec/unit/recipes/configure_spec.rb
+++ b/spec/unit/recipes/configure_spec.rb
@@ -660,7 +660,9 @@ describe 'opsworks_ruby::configure' do
     end
 
     it 'cleans default sites' do
-      expect(chef_run).to run_execute('find /etc/apache2/sites-enabled -maxdepth 1 -mindepth 1 -exec rm -rf {} \;')
+      %w[default default.conf 000-default 000-default.conf default-ssl default-ssl.conf].each do |file|
+        expect(chef_run).to delete_file("/etc/apache2/sites-enabled/#{file}")
+      end
     end
 
     it 'creates resque.monitrc conf' do
@@ -795,7 +797,9 @@ describe 'opsworks_ruby::configure' do
       end
 
       it 'cleans default sites' do
-        expect(chef_run_rhel).to run_execute('find /etc/httpd/sites-enabled -maxdepth 1 -mindepth 1 -exec rm -rf {} \;')
+        %w[default default.conf 000-default 000-default.conf default-ssl default-ssl.conf].each do |file|
+          expect(chef_run_rhel).to delete_file("/etc/httpd/sites-enabled/#{file}")
+        end
       end
     end
   end

--- a/test/integration/data_bags/maximum_override/aws_opsworks_app/yet_another_project.json
+++ b/test/integration/data_bags/maximum_override/aws_opsworks_app/yet_another_project.json
@@ -1,0 +1,34 @@
+{
+  "app_id": "4bf048d2-7e2b-4255-bbf1-03e06f07701a",
+  "app_source": {
+    "password": "3aa161d358a167204502",
+    "revision": "master",
+    "type": "git",
+    "url": "https://github.com/RapidRiverSoftware/dumber-app",
+    "user": "dummy"
+  },
+  "attributes": {
+    "auto_bundle_on_deploy": true,
+    "aws_flow_ruby_settings": {},
+    "document_root": "",
+    "rails_env": null
+  },
+  "data_sources": [],
+  "domains": [
+    "yet-another-project.example.com",
+    "yet_another_project"
+  ],
+  "enable_ssl": false,
+  "environment": {
+    "ENV_VAR1": "test"
+  },
+  "name": "Another Dummy app",
+  "shortname": "yet_another_project",
+  "ssl_configuration": {
+    "certificate": "",
+    "private_key": ""
+  },
+  "type": "other",
+  "deploy": true,
+  "id": "yet_another_project"
+}

--- a/test/integration/maximum_override/serverspec/maximum_override_spec.rb
+++ b/test/integration/maximum_override/serverspec/maximum_override_spec.rb
@@ -30,89 +30,190 @@ end
 
 describe 'opsworks_ruby::configure' do
   context 'webserver' do
-    describe file('/etc/logrotate.d/other_project-apache2-production') do
-      its(:owner) { should eq('root') }
-      its(:group) { should eq('root') }
-      its(:mode) { should eq('644') }
-      its(:content) { should include '"/tmp/log1.log" "/tmp/log2.log"' }
-      its(:content) { should include '  monthly' }
-      its(:content) { should include '  rotate 15' }
-      its(:content) { should include '  missingok' }
-      its(:content) { should_not include '  compress' }
-      its(:content) { should_not include '  delaycompress' }
-      its(:content) { should include '  notifempty' }
-      its(:content) { should_not include '  copytruncate' }
-      its(:content) { should_not include '  sharedscripts' }
+    context 'first installed app' do
+      describe file('/etc/logrotate.d/other_project-apache2-production') do
+        its(:owner) { should eq('root') }
+        its(:group) { should eq('root') }
+        its(:mode) { should eq('644') }
+        its(:content) { should include '"/tmp/log1.log" "/tmp/log2.log"' }
+        its(:content) { should include '  monthly' }
+        its(:content) { should include '  rotate 15' }
+        its(:content) { should include '  missingok' }
+        its(:content) { should_not include '  compress' }
+        its(:content) { should_not include '  delaycompress' }
+        its(:content) { should include '  notifempty' }
+        its(:content) { should_not include '  copytruncate' }
+        its(:content) { should_not include '  sharedscripts' }
+      end
+
+      describe file('/etc/apache2/ssl/other-project.example.com.key') do
+        its(:content) { should include '-----BEGIN RSA PRIVATE KEY-----' }
+      end
+
+      describe file('/etc/apache2/ssl/other-project.example.com.crt') do
+        its(:content) { should include '-----BEGIN CERTIFICATE-----' }
+      end
+
+      describe file('/etc/apache2/ssl/other-project.example.com.ca') do
+        it { should_not exist }
+      end
+
+      describe file('/etc/apache2/ssl/other-project.example.com.dhparams.pem') do
+        it { should_not exist }
+      end
+
+      describe file('/etc/apache2/sites-enabled/other_project.conf') do
+        it { should be_symlink }
+      end
+
+      %w[default default.conf 000-default 000-default.conf default-ssl default-ssl.conf].each do |file|
+        describe file("/etc/apache2/sites-enabled/#{file}") do
+          it { should_not exist }
+        end
+      end
+
+      describe file('/etc/apache2/sites-available/other_project.conf') do
+        its(:content) { should include 'SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH' }
+        its(:content) { should include 'DocumentRoot /srv/www/other_project/current/public' }
+        its(:content) { should_not include ' Proxy ' }
+        its(:content) { should include '<Location /some/mount/point>' }
+        its(:content) { should include 'PassengerAppEnv production' }
+        its(:content) { should include 'PassengerBaseURI /some/mount/point' }
+        its(:content) { should include 'PassengerMaxPoolSize 3' }
+        its(:content) { should include 'PassengerMinInstances 2' }
+        its(:content) { should include 'Listen 8080' }
+        its(:content) { should include '<VirtualHost *:8080>' }
+        its(:content) { should include 'Listen 8443' }
+        its(:content) { should include '<VirtualHost *:8443>' }
+      end
     end
 
-    describe file('/etc/apache2/ssl/other-project.example.com.key') do
-      its(:content) { should include '-----BEGIN RSA PRIVATE KEY-----' }
-    end
+    context 'second installed app' do
+      describe file('/etc/logrotate.d/yet_another_project-apache2-production') do
+        its(:owner) { should eq('deploy') }
+        its(:group) { should eq('root') }
+        its(:mode) { should eq('644') }
+        its(:content) { should include '"/var/log/apache2/yet-another-project.example.com.access.log"' }
+        its(:content) { should include '"/var/log/apache2/yet-another-project.example.com.error.log"' }
+        its(:content) { should include '  daily' }
+        its(:content) { should include '  rotate 75' }
+        its(:content) { should include '  missingok' }
+        its(:content) { should_not include '  compress' }
+        its(:content) { should_not include '  delaycompress' }
+        its(:content) { should include '  notifempty' }
+        its(:content) { should include '  copytruncate' }
+        its(:content) { should_not include '  sharedscripts' }
+      end
 
-    describe file('/etc/apache2/ssl/other-project.example.com.crt') do
-      its(:content) { should include '-----BEGIN CERTIFICATE-----' }
-    end
+      describe file('/etc/apache2/ssl/yet-another-project.example.com.key') do
+        it { should_not exist }
+      end
 
-    describe file('/etc/apache2/ssl/other-project.example.com.ca') do
-      it { should_not exist }
-    end
+      describe file('/etc/apache2/ssl/yet-another-project.example.com.crt') do
+        it { should_not exist }
+      end
 
-    describe file('/etc/apache2/ssl/other-project.example.com.dhparams.pem') do
-      it { should_not exist }
-    end
+      describe file('/etc/apache2/ssl/yet-another-project.example.com.ca') do
+        it { should_not exist }
+      end
 
-    describe file('/etc/apache2/sites-enabled/other_project.conf') do
-      it { should be_symlink }
-    end
+      describe file('/etc/apache2/ssl/yet-another-project.example.com.dhparams.pem') do
+        it { should_not exist }
+      end
 
-    describe file('/etc/apache2/sites-available/other_project.conf') do
-      its(:content) { should include 'SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH' }
-      its(:content) { should include 'DocumentRoot /srv/www/other_project/current/public' }
-      its(:content) { should_not include ' Proxy ' }
-      its(:content) { should include '<Location /some/mount/point>' }
-      its(:content) { should include 'PassengerAppEnv production' }
-      its(:content) { should include 'PassengerBaseURI /some/mount/point' }
-      its(:content) { should include 'PassengerMaxPoolSize 3' }
-      its(:content) { should include 'PassengerMinInstances 2' }
-      its(:content) { should include 'Listen 8080' }
-      its(:content) { should include '<VirtualHost *:8080>' }
-      its(:content) { should include 'Listen 8443' }
-      its(:content) { should include '<VirtualHost *:8443>' }
+      describe file('/etc/apache2/sites-enabled/yet_another_project.conf') do
+        it { should be_symlink }
+      end
+
+      describe file('/etc/apache2/sites-available/yet_another_project.conf') do
+        its(:content) { should_not include 'SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH' }
+        its(:content) { should include '<Proxy balancer://unicorn_yet_another_project_example_com>' }
+        its(:content) { should include 'DocumentRoot /srv/www/yet_another_project/current/public' }
+        its(:content) { should include 'Listen 8081' }
+        its(:content) { should include '<VirtualHost *:8081>' }
+        its(:content) { should_not include '<VirtualHost *:844' }
+      end
     end
   end
 
   context 'appserver' do
-    describe file('/srv/www/other_project/shared/config/unicorn.conf') do
-      it { should_not exist }
+    context 'first installed app' do
+      describe file('/srv/www/other_project/shared/config/unicorn.conf') do
+        it { should_not exist }
+      end
+
+      describe file('/srv/www/other_project/shared/scripts/unicorn.service') do
+        it { should_not exist }
+      end
     end
 
-    describe file('/srv/www/other_project/shared/scripts/unicorn.service') do
-      it { should_not exist }
+    context 'second installed app' do
+      describe file('/srv/www/yet_another_project/shared/config/unicorn.conf') do
+        its(:content) { should include ':backlog => 1024' }
+        its(:content) { should include ':tries => 5' }
+        its(:content) { should include 'listen "127.0.0.1:3000"' }
+      end
+
+      describe file('/srv/www/yet_another_project/shared/scripts/unicorn.service') do
+        its(:content) { should include 'ENV[\'ENV_VAR1\'] = "test"' }
+        its(:content) { should include 'ENV[\'RAILS_ENV\'] = "production"' }
+        its(:content) { should include 'ENV[\'HOME\'] = "/home/deploy"' }
+        its(:content) { should include 'ENV[\'USER\'] = "deploy"' }
+        its(:content) { should include 'PID_PATH="/srv/www/yet_another_project/shared/pids/unicorn.pid"' }
+        its(:content) { should include 'def unicorn_running?' }
+      end
     end
   end
 
   context 'framework' do
-    describe file('/etc/logrotate.d/other_project-rails-production') do
-      it { should_not exist }
+    context 'first installed app' do
+      describe file('/etc/logrotate.d/other_project-rails-production') do
+        it { should_not exist }
+      end
+
+      describe file('/etc/logrotate.d/dumber-app-logrotate') do
+        its(:owner) { should eq('deploy') }
+        its(:group) { should eq('www-data') }
+        its(:mode) { should eq('750') }
+        its(:content) { should include '"/srv/www/other_project/shared/log/*.log" {' }
+        its(:content) { should include '  weekly' }
+        its(:content) { should include '  rotate 75' }
+        its(:content) { should include '  missingok' }
+        its(:content) { should_not include '  compress' }
+        its(:content) { should_not include '  delaycompress' }
+        its(:content) { should include '  notifempty' }
+        its(:content) { should include '  copytruncate' }
+        its(:content) { should include '  sharedscripts' }
+      end
+
+      describe file('/srv/www/other_project/shared/config/.env.production') do
+        it { should_not exist }
+      end
     end
 
-    describe file('/etc/logrotate.d/dumber-app-logrotate') do
-      its(:owner) { should eq('deploy') }
-      its(:group) { should eq('www-data') }
-      its(:mode) { should eq('750') }
-      its(:content) { should include '"/srv/www/other_project/shared/log/*.log" {' }
-      its(:content) { should include '  weekly' }
-      its(:content) { should include '  rotate 75' }
-      its(:content) { should include '  missingok' }
-      its(:content) { should_not include '  compress' }
-      its(:content) { should_not include '  delaycompress' }
-      its(:content) { should include '  notifempty' }
-      its(:content) { should include '  copytruncate' }
-      its(:content) { should include '  sharedscripts' }
-    end
+    context 'second installed app' do
+      describe file('/etc/logrotate.d/yet_another_project-rails-production') do
+        it { should_not exist }
+      end
 
-    describe file('/srv/www/other_project/shared/config/.env.production') do
-      it { should_not exist }
+      describe file('/etc/logrotate.d/dumberer-app-logrotate') do
+        its(:owner) { should eq('deploy') }
+        its(:group) { should eq('www-data') }
+        its(:mode) { should eq('644') }
+        its(:content) { should include '"/srv/www/yet_another_project/shared/log/*.log" {' }
+        its(:content) { should include '  daily' }
+        its(:content) { should include '  rotate 75' }
+        its(:content) { should include '  missingok' }
+        its(:content) { should_not include '  compress' }
+        its(:content) { should_not include '  delaycompress' }
+        its(:content) { should include '  notifempty' }
+        its(:content) { should include '  copytruncate' }
+        its(:content) { should include '  sharedscripts' }
+      end
+
+      describe file('/srv/www/other_project/shared/config/.env.production') do
+        it { should_not exist }
+      end
     end
   end
 end
@@ -124,6 +225,10 @@ describe 'opsworks_ruby::deploy' do
     end
 
     describe file('/srv/www/other_project/current/.git') do
+      it { should_not exist }
+    end
+
+    describe file('/srv/www/yet_another_project/current/.git') do
       it { should_not exist }
     end
   end
@@ -145,7 +250,7 @@ describe 'opsworks_ruby::deploy' do
       it { should_not exist }
     end
 
-    describe file('/srv/www/other_project/current/config/database.yml') do
+    describe file('/srv/www/yet_another_project/current/config/database.yml') do
       it { should be_symlink }
     end
   end


### PR DESCRIPTION
In order to ensure that default sites provided by the OS
package manager did not conflict with application site
configs, the apache2 provider was over-enthusiastically
deleting *all* enabled sites every time it configured and
enabled any site. Also this had the effect of getting rid
of any enabled default site config, it also got rid of
any other enabled application site config, making it
impossible to run multiple apps under the same Apache2
web server. Some of us actually do that! So this fixes it.

Fixes #111