### PR TITLE
fix(logrotate): remove duplicate log entry in config file generated f…

### DIFF
--- a/libraries/drivers_dsl_logrotate.rb
+++ b/libraries/drivers_dsl_logrotate.rb
@@ -28,6 +28,18 @@ module Drivers
           path   lr_path
           lr_props.each { |k, v| send(k.to_sym, v) unless v.nil? }
         end
+        remove_default_conf
+      end
+
+      def remove_default_conf
+        context.logrotate_app adapter do
+          enable false # option that will soon be deprecated
+          action :disable # new option but not working as of this version
+        end
+      end
+
+      def logrotate_directory
+        context.node['defaults']['global']['logrotate_directory']
       end
 
       def logrotate_name
@@ -51,7 +63,7 @@ module Drivers
           (context.node['deploy'][app['shortname']].try(:[], 'global').try(:keys) || []) +
           (context.node['defaults'][driver_type].keys || []) +
           (context.node['defaults']['global'].keys || [])
-        all_keys.uniq.map { |k| Regexp.last_match(1) if k =~ /^logrotate_(.+)/ }.compact - %w[name log_paths]
+        all_keys.uniq.map { |k| Regexp.last_match(1) if k =~ /^logrotate_(.+)/ }.compact - %w[name log_paths directory]
       end
       # rubocop:enable Metrics/AbcSize
 

--- a/spec/unit/recipes/configure_spec.rb
+++ b/spec/unit/recipes/configure_spec.rb
@@ -81,6 +81,10 @@ describe 'opsworks_ruby::configure' do
         .to enable_logrotate_app("#{aws_opsworks_app['shortname']}-nginx-staging")
     end
 
+    it 'deletes default logrotate file for nginx' do
+      expect(chef_run).to disable_logrotate_app('nginx')
+    end
+
     context 'when the logrotate settings are overridden by attributes at various levels of precedence' do
       let(:logrotate_paths) { %w[/some/path/to/a.log] }
       let(:chef_runner) do
@@ -482,6 +486,10 @@ describe 'opsworks_ruby::configure' do
         .to enable_logrotate_app("#{aws_opsworks_app['shortname']}-apache2-staging")
     end
 
+    it 'deletes default logrotate file for apache2' do
+      expect(chef_run).to disable_logrotate_app('apache2')
+    end
+
     it 'creates proper .env.*' do
       db_config =
         Drivers::Db::Mysql.new(chef_run, aws_opsworks_app, rds: aws_opsworks_rds_db_instance(engine: 'mysql')).out
@@ -869,6 +877,10 @@ describe 'opsworks_ruby::configure' do
     it 'creates logrotate file for rails' do
       expect(chef_run)
         .to enable_logrotate_app("#{aws_opsworks_app['shortname']}-rails-production")
+    end
+
+    it 'deletes default logrotate file for apache2' do
+      expect(chef_run).to disable_logrotate_app('apache2')
     end
 
     context 'when default ports are overridden' do


### PR DESCRIPTION
This fixes this [issue](https://github.com/ajgon/opsworks_ruby/issues/117).

As you can see from the latest commit of the [logrotate cookbook](https://github.com/stevendanna/logrotate/blob/083672da704ebb9a3e8459b635036162f5e9e316/resources/app.rb#L44), there are 2 ways to go about this. and one of them is being deprecated, while the other one doesnt work yet on this version.