### PR TITLE
fix: failed to start app server.

### DIFF
--- a/libraries/drivers_appserver_puma.rb
+++ b/libraries/drivers_appserver_puma.rb
@@ -12,7 +12,7 @@ module Drivers
       end
 
       def appserver_command
-        'puma -C #\{ROOT_PATH\}/shared/config/puma.rb'
+        'puma -C #{ROOT_PATH}/shared/config/puma.rb'
       end
     end
   end

--- a/libraries/drivers_appserver_thin.rb
+++ b/libraries/drivers_appserver_thin.rb
@@ -12,7 +12,7 @@ module Drivers
       end
 
       def appserver_command
-        'thin -C #\{ROOT_PATH\}/shared/config/thin.yml'
+        'thin -C #{ROOT_PATH}/shared/config/thin.yml'
       end
     end
   end

--- a/libraries/drivers_appserver_unicorn.rb
+++ b/libraries/drivers_appserver_unicorn.rb
@@ -14,7 +14,7 @@ module Drivers
       end
 
       def appserver_command
-        'unicorn_rails --env #\{DEPLOY_ENV\} --daemonize -c #\{ROOT_PATH\}/shared/config/unicorn.conf'
+        'unicorn_rails --env #{DEPLOY_ENV} --daemonize -c #{ROOT_PATH}/shared/config/unicorn.conf'
       end
     end
   end

--- a/spec/unit/recipes/configure_spec.rb
+++ b/spec/unit/recipes/configure_spec.rb
@@ -195,7 +195,7 @@ describe 'opsworks_ruby::configure' do
         .with_content('DEPLOY_ENV="staging"')
       expect(chef_run)
         .to render_file("/srv/www/#{aws_opsworks_app['shortname']}/shared/scripts/unicorn.service")
-        .with_content('unicorn_rails --env #\{DEPLOY_ENV\} --daemonize -c #\{ROOT_PATH\}/shared/config/unicorn.conf')
+        .with_content('unicorn_rails --env #{DEPLOY_ENV} --daemonize -c #{ROOT_PATH}/shared/config/unicorn.conf')
     end
 
     it 'defines unicorn service' do
@@ -565,7 +565,7 @@ describe 'opsworks_ruby::configure' do
         .with_content('DEPLOY_ENV="staging"')
       expect(chef_run)
         .to render_file("/srv/www/#{aws_opsworks_app['shortname']}/shared/scripts/puma.service")
-        .with_content('puma -C #\{ROOT_PATH\}/shared/config/puma.rb')
+        .with_content('puma -C #{ROOT_PATH}/shared/config/puma.rb')
     end
 
     it 'defines puma service' do
@@ -979,7 +979,7 @@ describe 'opsworks_ruby::configure' do
         .with_content('DEPLOY_ENV="staging"')
       expect(chef_run)
         .to render_file("/srv/www/#{aws_opsworks_app['shortname']}/shared/scripts/thin.service")
-        .with_content('thin -C #\{ROOT_PATH\}/shared/config/thin.yml')
+        .with_content('thin -C #{ROOT_PATH}/shared/config/thin.yml')
     end
 
     it 'defines thin service' do


### PR DESCRIPTION
I've found below problem and fixed. 😄 
Please check and merge it.

ex)
```
$ /srv/www/rails/shared/scripts/puma.service start
Set Puma process UID to 5000
Starting Puma rails
cd /srv/www/rails/current && /usr/local/bin/bundle exec puma -C #{ROOT_PATH}/shared/config/puma.rb
/srv/www/rails/shared/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/cli.rb:47:in `initialize': missing argument: -C (OptionParser::MissingArgument)
	from /srv/www/rails/shared/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/bin/puma:8:in `new'
	from /srv/www/rails/shared/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/bin/puma:8:in `<top (required)>'
	from /srv/www/rails/shared/vendor/bundle/ruby/2.4.0/bin/puma:23:in `load'
	from /srv/www/rails/shared/vendor/bundle/ruby/2.4.0/bin/puma:23:in `<main>'
```