### PR TITLE
Use several ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ services:
   - docker
 
 rvm:
-  - 'ruby-2.4.0'
+  - 2.0.0  # default AWS version
+  - 2.4.2  # last AWS version
 
 addons:
   apt:


### PR DESCRIPTION
Hi,

The default **ruby** version on  *Amazon Linux* is `2.0.0`.

It could be useful to test this against this ruby version.

Regards,

PS : The last version is `2.4.2`, I have changer from `2.4.0`