### PR TITLE
ci(cache): avoid caching system gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ services:
   - docker
 
 # Use caching feature
-cache: bundler
+cache:
+  directories:
+    - vendor/bundle
 
 rvm:
   - 2.0.0  # default AWS version


### PR DESCRIPTION
I notice that in my PR #136, the system gems was added to CI cache.

So caching was inefficient