### PR TITLE
fix: failed to start appserver.

### DIFF
--- a/libraries/drivers_appserver_puma.rb
+++ b/libraries/drivers_appserver_puma.rb
@@ -12,7 +12,7 @@ module Drivers
       end
 
       def appserver_command
-        'puma -C #\{ROOT_PATH\}/shared/config/puma.rb'
+        'puma -C #{ROOT_PATH}/shared/config/puma.rb' # rubocop:disable Lint/InterpolationCheck
       end
     end
   end

--- a/libraries/drivers_appserver_thin.rb
+++ b/libraries/drivers_appserver_thin.rb
@@ -12,7 +12,7 @@ module Drivers
       end
 
       def appserver_command
-        'thin -C #\{ROOT_PATH\}/shared/config/thin.yml'
+        'thin -C #{ROOT_PATH}/shared/config/thin.yml' # rubocop:disable Lint/InterpolationCheck
       end
     end
   end

--- a/libraries/drivers_appserver_unicorn.rb
+++ b/libraries/drivers_appserver_unicorn.rb
@@ -14,7 +14,9 @@ module Drivers
       end
 
       def appserver_command
-        'unicorn_rails --env #\{DEPLOY_ENV\} --daemonize -c #\{ROOT_PATH\}/shared/config/unicorn.conf'
+        # rubocop:disable Lint/InterpolationCheck
+        'unicorn_rails --env #{DEPLOY_ENV} --daemonize -c #{ROOT_PATH}/shared/config/unicorn.conf'
+        # rubocop:enable Lint/InterpolationCheck
       end
     end
   end

--- a/spec/unit/recipes/configure_spec.rb
+++ b/spec/unit/recipes/configure_spec.rb
@@ -193,9 +193,11 @@ describe 'opsworks_ruby::configure' do
       expect(chef_run)
         .to render_file("/srv/www/#{aws_opsworks_app['shortname']}/shared/scripts/unicorn.service")
         .with_content('DEPLOY_ENV="staging"')
+      # rubocop:disable Lint/InterpolationCheck
       expect(chef_run)
         .to render_file("/srv/www/#{aws_opsworks_app['shortname']}/shared/scripts/unicorn.service")
-        .with_content('unicorn_rails --env #\{DEPLOY_ENV\} --daemonize -c #\{ROOT_PATH\}/shared/config/unicorn.conf')
+        .with_content('unicorn_rails --env #{DEPLOY_ENV} --daemonize -c #{ROOT_PATH}/shared/config/unicorn.conf')
+      # rubocop:enable Lint/InterpolationCheck
     end
 
     it 'defines unicorn service' do
@@ -563,9 +565,11 @@ describe 'opsworks_ruby::configure' do
       expect(chef_run)
         .to render_file("/srv/www/#{aws_opsworks_app['shortname']}/shared/scripts/puma.service")
         .with_content('DEPLOY_ENV="staging"')
+      # rubocop:disable Lint/InterpolationCheck
       expect(chef_run)
         .to render_file("/srv/www/#{aws_opsworks_app['shortname']}/shared/scripts/puma.service")
-        .with_content('puma -C #\{ROOT_PATH\}/shared/config/puma.rb')
+        .with_content('puma -C #{ROOT_PATH}/shared/config/puma.rb')
+      # rubocop:enable Lint/InterpolationCheck
     end
 
     it 'defines puma service' do
@@ -977,9 +981,11 @@ describe 'opsworks_ruby::configure' do
       expect(chef_run)
         .to render_file("/srv/www/#{aws_opsworks_app['shortname']}/shared/scripts/thin.service")
         .with_content('DEPLOY_ENV="staging"')
+      # rubocop:disable Lint/InterpolationCheck
       expect(chef_run)
         .to render_file("/srv/www/#{aws_opsworks_app['shortname']}/shared/scripts/thin.service")
-        .with_content('thin -C #\{ROOT_PATH\}/shared/config/thin.yml')
+        .with_content('thin -C #{ROOT_PATH}/shared/config/thin.yml')
+      # rubocop:enable Lint/InterpolationCheck
     end
 
     it 'defines thin service' do


### PR DESCRIPTION
ex)
$ /srv/www/rails/shared/scripts/puma.service start
Set Puma process UID to 5000
Starting Puma rails
cd /srv/www/rails/current && /usr/local/bin/bundle exec puma -C #{ROOT_PATH}/shared/config/puma.rb
/srv/www/rails/shared/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/cli.rb:47:in `initialize': missing argument: -C (OptionParser::MissingArgument)
	from /srv/www/rails/shared/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/bin/puma:8:in `new'
	from /srv/www/rails/shared/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/bin/puma:8:in `<top (required)>'
	from /srv/www/rails/shared/vendor/bundle/ruby/2.4.0/bin/puma:23:in `load'
	from /srv/www/rails/shared/vendor/bundle/ruby/2.4.0/bin/puma:23:in `<main>'