### PR TITLE
bumps postgresql package to 9.6 (current RDS default)

### DIFF
--- a/libraries/drivers_db_postgresql.rb
+++ b/libraries/drivers_db_postgresql.rb
@@ -5,7 +5,7 @@ module Drivers
     class Postgresql < Base
       adapter :postgresql
       allowed_engines :postgres, :postgresql
-      packages debian: 'libpq-dev', rhel: 'postgresql94-devel'
+      packages debian: 'libpq-dev', rhel: 'postgresql96-devel'
     end
   end
 end

--- a/spec/unit/recipes/setup_spec.rb
+++ b/spec/unit/recipes/setup_spec.rb
@@ -241,7 +241,7 @@ describe 'opsworks_ruby::setup' do
       expect(chef_run_rhel).to install_package('nginx')
       expect(chef_run_rhel).to install_package('zlib-devel')
       expect(chef_run_rhel).to install_package('git')
-      expect(chef_run_rhel).to install_package('postgresql94-devel')
+      expect(chef_run_rhel).to install_package('postgresql96-devel')
       expect(chef_run_rhel).to install_package('redis')
       expect(chef_run_rhel).to install_package('monit')
       expect(chef_run_rhel).to install_package('tzdata')


### PR DESCRIPTION
we need to have packages in sync with RDS to use tools like `pg_dump` (currently getting an error message `pg_dump: aborting because of server version mismatch`)