### PR TITLE
Puma restart / hook support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,6 +60,9 @@ default['defaults']['appserver']['worker_processes'] = 4
 default['defaults']['appserver']['log_requests'] = false
 default['defaults']['appserver']['thread_min'] = 0
 default['defaults']['appserver']['thread_max'] = 16
+default['defaults']['appserver']['restart_signal'] = 'USR2'
+# for rolling restart use USR1
+# default['defaults']['appserver']['restart_signal'] = 'USR1'
 
 ## thin
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,7 +54,7 @@ default['defaults']['appserver']['dot_env'] = false
 default['defaults']['appserver']['preload_app'] = true
 default['defaults']['appserver']['timeout'] = 60
 default['defaults']['appserver']['worker_processes'] = 4
-default['defaults']['appserver']['after_deploy'] = 'start-stop' # (restart|clean-restart)
+default['defaults']['appserver']['after_deploy'] = 'stop-start' # (restart|clean-restart)
 
 ## puma
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,9 +60,6 @@ default['defaults']['appserver']['worker_processes'] = 4
 default['defaults']['appserver']['log_requests'] = false
 default['defaults']['appserver']['thread_min'] = 0
 default['defaults']['appserver']['thread_max'] = 16
-default['defaults']['appserver']['restart_signal'] = 'USR2'
-# for rolling restart use USR1
-# default['defaults']['appserver']['restart_signal'] = 'USR1'
 default['defaults']['appserver']['on_restart'] = nil
 default['defaults']['appserver']['before_fork'] = nil
 default['defaults']['appserver']['on_worker_boot'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,6 +54,7 @@ default['defaults']['appserver']['dot_env'] = false
 default['defaults']['appserver']['preload_app'] = true
 default['defaults']['appserver']['timeout'] = 60
 default['defaults']['appserver']['worker_processes'] = 4
+default['defaults']['appserver']['after_deploy'] = 'start-stop' # (restart|clean-restart)
 
 ## puma
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -63,6 +63,12 @@ default['defaults']['appserver']['thread_max'] = 16
 default['defaults']['appserver']['restart_signal'] = 'USR2'
 # for rolling restart use USR1
 # default['defaults']['appserver']['restart_signal'] = 'USR1'
+default['defaults']['appserver']['on_restart'] = nil
+default['defaults']['appserver']['before_fork'] = nil
+default['defaults']['appserver']['on_worker_boot'] = nil
+default['defaults']['appserver']['on_worker_shutdown'] = nil
+default['defaults']['appserver']['on_worker_fork'] = nil
+default['defaults']['appserver']['after_worker_fork'] = nil
 
 ## thin
 

--- a/docs/source/attributes.rst
+++ b/docs/source/attributes.rst
@@ -411,6 +411,21 @@ appserver
      version provided by the Passenger APT PPA. Set this to a non-nil
      value to lock your Passenger installation at a specific version.
 
+- ``app['appserver']['after_deploy']``
+
+  - **Default:** ``stop-start``
+  - **Supported values:** ``stop-start``, ``restart``, ``clean-restart``
+  - Tell the appserver how to restart following a deployment.  A ``stop-start``
+    will instruct the appserver to stop and then start immediately.  This is
+    can cause requests from the webserver to be dropped since it closes the socket.
+    A ``restart`` sends a signal to the appserver instructing it to restart while
+    maintaining the open socket.  Requests will hang while the app boots, but
+    will not be lost. A ``clean-restart`` will perform a ``stop-start`` if the
+    Gemfile has changed or a ``restart`` otherwise.  The behavior of each of
+    these approaches varies between appservers.  See their documentation for more
+    details.
+
+
 unicorn
 ^^^^^^^
 
@@ -451,6 +466,30 @@ puma
 -  |app['appserver']['thread_min']|_
 
   -  **Default:** ``0``
+
+-  |app['appserver']['on_restart']|_
+
+  - Code to run before doing a restart. This code should close log files, database connections, etc.
+
+-  |app['appserver']['before_fork']|_
+
+  - Code to run immediately before the master starts workers.
+
+-  |app['appserver']['on_worker_boot']|_
+
+  - Code to run in a worker before it starts serving requests. This is called everytime a worker is to be started.
+
+-  |app['appserver']['on_worker_shutdown']|_
+
+  - Code to run in a worker right before it exits. This is called everytime a worker is to about to shutdown.
+
+-  |app['appserver']['on_worker_fork']|_
+
+  - Code to run in the master right before a worker is started. The worker's index is passed as an argument. This is called everytime a worker is to be started.
+
+-  |app['appserver']['after_worker_fork']|_
+
+  - Code to run in the master after a worker has been started. The worker's index is passed as an argument. This is called everytime a worker is to be started.
 
 thin
 ^^^^
@@ -729,6 +768,18 @@ resque
 .. _app['appserver']['thread_max']: https://github.com/puma/puma/blob/c169853ff233dd3b5c4e8ed17e84e1a6d8cb565c/examples/config.rb#L62
 .. |app['appserver']['thread_min']| replace:: ``app['appserver']['thread_min']``
 .. _app['appserver']['thread_min']: https://github.com/puma/puma/blob/c169853ff233dd3b5c4e8ed17e84e1a6d8cb565c/examples/config.rb#L62
+.. |app['appserver']['on_restart']| replace:: ``app['appserver']['on_restart']``
+.. _app['appserver']['on_restart']: https://github.com/puma/puma/blob/e4255d03fb57021c96f7d03a3784b21b6e85b35b/examples/config.rb#L90
+.. |app['appserver']['before_fork']| replace:: ``app['appserver']['before_fork']``
+.. _app['appserver']['before_fork']: https://github.com/puma/puma/blob/e4255d03fb57021c96f7d03a3784b21b6e85b35b/examples/config.rb#L116
+.. |app['appserver']['on_worker_boot']| replace:: ``app['appserver']['on_worker_boot']``
+.. _app['appserver']['on_worker_boot']: https://github.com/puma/puma/blob/e4255d03fb57021c96f7d03a3784b21b6e85b35b/examples/config.rb#L124
+.. |app['appserver']['on_worker_shutdown']| replace:: ``app['appserver']['on_worker_shutdown']``
+.. _app['appserver']['on_worker_shutdown']: https://github.com/puma/puma/blob/e4255d03fb57021c96f7d03a3784b21b6e85b35b/examples/config.rb#L132
+.. |app['appserver']['on_worker_fork']| replace:: ``app['appserver']['on_worker_fork']``
+.. _app['appserver']['on_worker_fork']: https://github.com/puma/puma/blob/e4255d03fb57021c96f7d03a3784b21b6e85b35b/examples/config.rb#L141
+.. |app['appserver']['after_worker_fork']| replace:: ``app['appserver']['after_worker_fork']``
+.. _app['appserver']['after_worker_fork']: https://github.com/puma/puma/blob/e4255d03fb57021c96f7d03a3784b21b6e85b35b/examples/config.rb#L150
 .. _Read more here.: https://weakdh.org/sysadmin.html
 .. _covered in this article: https://cipherli.st/
 .. |app['webserver']['limit_request_body']| replace:: ``app['webserver']['limit_request_body']``

--- a/libraries/drivers_appserver_base.rb
+++ b/libraries/drivers_appserver_base.rb
@@ -19,8 +19,9 @@ module Drivers
       end
 
       def after_deploy
-        manual_action(:stop)
-        manual_action(:start)
+        action = node['deploy'][app['shortname']]['appserver']['after_deploy'] ||
+                 node['defaults']['appserver']['after_deploy']
+        manual_action(action)
       end
       alias after_undeploy after_deploy
 
@@ -48,6 +49,7 @@ module Drivers
 
         context.execute "#{action} #{adapter}" do
           command "#{service_script} #{action}"
+          live_stream true
         end
       end
 

--- a/libraries/drivers_appserver_base.rb
+++ b/libraries/drivers_appserver_base.rb
@@ -19,7 +19,7 @@ module Drivers
       end
 
       def after_deploy
-        action = node['deploy'][app['shortname']]['appserver']['after_deploy'] ||
+        action = node['deploy'][app['shortname']].try(:[], 'appserver').try(:[], 'after_deploy') ||
                  node['defaults']['appserver']['after_deploy']
         manual_action(action)
       end

--- a/libraries/drivers_appserver_puma.rb
+++ b/libraries/drivers_appserver_puma.rb
@@ -6,8 +6,8 @@ module Drivers
       adapter :puma
       allowed_engines :puma
       output filter: %i[log_requests preload_app thread_max thread_min timeout
-                        on_restart worker_processes before_fork on_worker_boot
-                        on_worker_shutdown on_worker_fork after_worker_fork]
+                        on_restart worker_processes before_fork on_worker_boot on_worker_shutdown
+                        on_worker_fork after_worker_fork after_deploy]
 
       def appserver_config
         'puma.rb'

--- a/libraries/drivers_appserver_puma.rb
+++ b/libraries/drivers_appserver_puma.rb
@@ -6,7 +6,7 @@ module Drivers
       adapter :puma
       allowed_engines :puma
       output filter: %i[log_requests preload_app thread_max thread_min timeout
-                        on_restart worker_processes restart_signal before_fork on_worker_boot
+                        on_restart worker_processes before_fork on_worker_boot
                         on_worker_shutdown on_worker_fork after_worker_fork]
 
       def appserver_config
@@ -15,11 +15,6 @@ module Drivers
 
       def appserver_command
         'puma -C #{ROOT_PATH}/shared/config/puma.rb' # rubocop:disable Lint/InterpolationCheck
-      end
-
-      # After deploying, tell Puma to restart instead of doing a stop/start cycle
-      def after_deploy
-        manual_action('restart')
       end
     end
   end

--- a/libraries/drivers_appserver_puma.rb
+++ b/libraries/drivers_appserver_puma.rb
@@ -5,7 +5,9 @@ module Drivers
     class Puma < Drivers::Appserver::Base
       adapter :puma
       allowed_engines :puma
-      output filter: %i[log_requests preload_app thread_max thread_min timeout worker_processes restart_signal]
+      output filter: %i[log_requests preload_app thread_max thread_min timeout
+                        on_restart worker_processes restart_signal before_fork on_worker_boot
+                        on_worker_shutdown on_worker_fork after_worker_fork]
 
       def appserver_config
         'puma.rb'

--- a/libraries/drivers_appserver_puma.rb
+++ b/libraries/drivers_appserver_puma.rb
@@ -5,7 +5,7 @@ module Drivers
     class Puma < Drivers::Appserver::Base
       adapter :puma
       allowed_engines :puma
-      output filter: %i[log_requests preload_app thread_max thread_min timeout worker_processes]
+      output filter: %i[log_requests preload_app thread_max thread_min timeout worker_processes restart_signal]
 
       def appserver_config
         'puma.rb'
@@ -13,6 +13,11 @@ module Drivers
 
       def appserver_command
         'puma -C #{ROOT_PATH}/shared/config/puma.rb' # rubocop:disable Lint/InterpolationCheck
+      end
+
+      # After deploying, tell Puma to restart instead of doing a stop/start cycle
+      def after_deploy
+        manual_action('restart')
       end
     end
   end

--- a/spec/fixtures/node.rb
+++ b/spec/fixtures/node.rb
@@ -80,7 +80,8 @@ DEFAULT_NODE = {
     },
     appserver: {
       adapter: 'unicorn',
-      worker_processes: 8
+      worker_processes: 8,
+      after_deploy: 'stop-start'
     },
     webserver: {
       adapter: 'nginx',

--- a/spec/unit/libraries/drivers_appserver_puma_spec.rb
+++ b/spec/unit/libraries/drivers_appserver_puma_spec.rb
@@ -16,6 +16,6 @@ describe Drivers::Appserver::Puma do
   end
 
   it 'returns proper out data' do
-    expect(driver.out).to eq(worker_processes: 8, thread_min: 0, thread_max: 16)
+    expect(driver.out).to eq(worker_processes: 8, thread_min: 0, thread_max: 16, after_deploy: 'stop-start')
   end
 end

--- a/spec/unit/recipes/deploy_spec.rb
+++ b/spec/unit/recipes/deploy_spec.rb
@@ -105,8 +105,7 @@ describe 'opsworks_ruby::deploy' do
       )
 
       expect(chef_run).to disable_logrotate_app('rails')
-      expect(chef_run).to run_execute('stop unicorn')
-      expect(chef_run).to run_execute('start unicorn')
+      expect(chef_run).to run_execute('stop-start unicorn')
       expect(deploy).to notify('service[nginx]').to(:reload).delayed
       expect(service).to do_nothing
     end
@@ -202,16 +201,14 @@ describe 'opsworks_ruby::deploy' do
       deploy_debian = chef_run.deploy(aws_opsworks_app['shortname'])
 
       expect(deploy_debian).to notify('service[apache2]').to(:reload).delayed
-      expect(chef_run).to run_execute('stop puma')
-      expect(chef_run).to run_execute('start puma')
+      expect(chef_run).to run_execute('stop-start puma')
     end
 
     it 'performs a deploy on rhel' do
       deploy_rhel = chef_run_rhel.deploy(aws_opsworks_app['shortname'])
 
       expect(deploy_rhel).to notify('service[httpd]').to(:reload).delayed
-      expect(chef_run_rhel).to run_execute('stop puma')
-      expect(chef_run_rhel).to run_execute('start puma')
+      expect(chef_run_rhel).to run_execute('stop-start puma')
     end
 
     it 'restarts resques via monit' do
@@ -280,13 +277,11 @@ describe 'opsworks_ruby::deploy' do
     end
 
     it 'performs a deploy on debian' do
-      expect(chef_run).to run_execute('stop thin')
-      expect(chef_run).to run_execute('start thin')
+      expect(chef_run).to run_execute('stop-start thin')
     end
 
     it 'performs a deploy on rhel' do
-      expect(chef_run_rhel).to run_execute('stop thin')
-      expect(chef_run_rhel).to run_execute('start thin')
+      expect(chef_run_rhel).to run_execute('stop-start thin')
     end
 
     it 'restarts delayed_jobs via monit' do

--- a/spec/unit/recipes/undeploy_spec.rb
+++ b/spec/unit/recipes/undeploy_spec.rb
@@ -27,8 +27,7 @@ describe 'opsworks_ruby::undeploy' do
       service = chef_run.service('nginx')
 
       expect(chef_run).to rollback_deploy('dummy_project')
-      expect(chef_run).to run_execute('stop unicorn')
-      expect(chef_run).to run_execute('start unicorn')
+      expect(chef_run).to run_execute('stop-start unicorn')
 
       expect(undeploy).to notify('service[nginx]').to(:reload).delayed
       expect(service).to do_nothing
@@ -64,16 +63,14 @@ describe 'opsworks_ruby::undeploy' do
       undeploy_debian = chef_run.deploy(aws_opsworks_app['shortname'])
 
       expect(undeploy_debian).to notify('service[apache2]').to(:reload).delayed
-      expect(chef_run).to run_execute('stop puma')
-      expect(chef_run).to run_execute('start puma')
+      expect(chef_run).to run_execute('stop-start puma')
     end
 
     it 'performs a rollback on rhel' do
       undeploy_rhel = chef_run_rhel.deploy(aws_opsworks_app['shortname'])
 
       expect(undeploy_rhel).to notify('service[httpd]').to(:reload).delayed
-      expect(chef_run_rhel).to run_execute('stop puma')
-      expect(chef_run_rhel).to run_execute('start puma')
+      expect(chef_run_rhel).to run_execute('stop-start puma')
     end
 
     it 'restarts resques via monit' do
@@ -101,13 +98,11 @@ describe 'opsworks_ruby::undeploy' do
     end
 
     it 'performs a rollback on debian' do
-      expect(chef_run).to run_execute('stop thin')
-      expect(chef_run).to run_execute('start thin')
+      expect(chef_run).to run_execute('stop-start thin')
     end
 
     it 'performs a rollback on rhel' do
-      expect(chef_run_rhel).to run_execute('stop thin')
-      expect(chef_run_rhel).to run_execute('start thin')
+      expect(chef_run_rhel).to run_execute('stop-start thin')
     end
 
     it 'restarts delayed_jobs via monit' do

--- a/templates/default/appserver.service.erb
+++ b/templates/default/appserver.service.erb
@@ -22,7 +22,7 @@ def run_and_ignore_exitcode_and_print_command(command)
   system(command)
 end
 
-def <%= @name %>_running?
+def running?
   if File.exists?(PID_PATH) && (pid = File.read(PID_PATH).chomp) && system("ps aux | grep #{pid} | grep -v grep > /dev/null")
     pid
   else
@@ -41,20 +41,22 @@ def different_gemfile?
   false
 end
 
-def start_<%= @name %>
+def start
+  puts "Starting <%= @name.capitalize %> #{APP_NAME}"
   run_and_ignore_exitcode_and_print_command "cd #{ROOT_PATH}/current && /usr/local/bin/bundle exec <%= @command %>"
 end
 
-def stop_<%= @name %>
-  unless <%= @name %>_running?
+def stop
+  unless running?
     puts "You can't stop <%= @name %>, because it's not running"
     return
   end
 
+  puts "Stopping <%= @name.capitalize %> #{APP_NAME}"
   retries = 10
 
   loop do
-    break if !<%= @name %>_running? || retries <= 0
+    break if !running? || retries <= 0
 
     run_and_ignore_exitcode_and_print_command "kill -QUIT `cat #{PID_PATH}`"
     sleep 1
@@ -64,32 +66,35 @@ def stop_<%= @name %>
   `rm #{PID_PATH}` if run_and_ignore_exitcode_and_print_command "kill -QUIT `cat #{PID_PATH}`"
 end
 
-def restart_<%= @name %>
-  if <%= @name %>_running?
+def stop_start
+  stop
+  start
+end
+
+def restart
+  if running?
+    puts "Restarting <%= @name.capitalize %> #{APP_NAME}"
     run_and_ignore_exitcode_and_print_command "kill -USR2 `cat #{PID_PATH}`"
   else
-    start_<%= @name %>
+    start
   end
 end
 
 def clean_restart
   if different_gemfile?
     puts "Found a previous version with a different Gemfile: Doing a stop & start"
-    stop_<%= @name %> if <%= @name %>_running?
-    start_<%= @name %>
+    stop_start
   else
-    puts "No previous version with a different Gemfile found. Assuming a quick restart without re-loading gems is save"
-    restart_<%= @name %>
+    puts "No previous version with a different Gemfile found. Assuming a quick restart without re-loading gems is safe"
+    restart
   end
 end
 
-def status_<%= @name %>
-  if pid = <%= @name %>_running?
-    puts "<%= @name.capitalize %> <%= @app_shortname %> running with PID #{pid}"
-    return true
+def status
+  if pid = running?
+    puts "<%= @name.capitalize %> #{APP_NAME} running with PID #{pid}"
   else
-    puts "<%= @name.capitalize %> <%= @app_shortname %> not running"
-    return false
+    puts "<%= @name.capitalize %> #{APP_NAME} not running"
   end
 end
 
@@ -98,19 +103,20 @@ puts "Set <%= @name.capitalize %> process UID to #{uid}"
 
 case ARGV[0]
 when "start"
-  puts "Starting <%= @name.capitalize %> #{APP_NAME}"
-  start_<%= @name %>
+  start
 when "stop"
-  puts "Stopping <%= @name.capitalize %> #{APP_NAME}"
-  stop_<%= @name %>
+  stop
 when "status"
-  status_<%= @name %>
+  status
 when "restart"
-  restart_<%= @name %>
+  restart
 when "clean-restart"
   clean_restart
+when "stop-start"
+  puts "Stopping <%= @name.capitalize %> #{APP_NAME}"
+  stop_start
 else
-  puts "Usage: {start|stop|status|restart|clean-restart}"
+  puts "Usage: {start|stop|status|restart|clean-restart|stop-start}"
   exit 1
 end
 

--- a/templates/default/appserver.service.erb
+++ b/templates/default/appserver.service.erb
@@ -66,7 +66,7 @@ end
 
 def restart_<%= @name %>
   if <%= @name %>_running?
-    run_and_ignore_exitcode_and_print_command "kill -<%= @restart_signal || 'USR2' %> `cat #{PID_PATH}`"
+    run_and_ignore_exitcode_and_print_command "kill -USR2 `cat #{PID_PATH}`"
   else
     start_<%= @name %>
   end

--- a/templates/default/appserver.service.erb
+++ b/templates/default/appserver.service.erb
@@ -66,7 +66,7 @@ end
 
 def restart_<%= @name %>
   if <%= @name %>_running?
-    run_and_ignore_exitcode_and_print_command "kill -USR2 `cat #{PID_PATH}`"
+    run_and_ignore_exitcode_and_print_command "kill -<%= @restart_signal || 'USR2' %> `cat #{PID_PATH}`"
   else
     start_<%= @name %>
   end

--- a/templates/default/appserver.service.erb
+++ b/templates/default/appserver.service.erb
@@ -113,7 +113,6 @@ when "restart"
 when "clean-restart"
   clean_restart
 when "stop-start"
-  puts "Stopping <%= @name.capitalize %> #{APP_NAME}"
   stop_start
 else
   puts "Usage: {start|stop|status|restart|clean-restart|stop-start}"

--- a/templates/default/puma.rb.erb
+++ b/templates/default/puma.rb.erb
@@ -83,7 +83,7 @@ workers <%= @out[:worker_processes] %>
 #   puts "Starting workers..."
 # end
 before_fork do
-  <%= @out[:before_fork] %>
+  <%= @out[:before_fork] || 'puts "Starting workers..."'%>
 end
 
 # Code to run in a worker before it starts serving requests.
@@ -94,7 +94,7 @@ end
 #   puts 'On worker boot...'
 # end
 on_worker_boot do
-  <%= @out[:on_worker_boot] %>
+  <%= @out[:on_worker_boot] || 'puts "On worker boot..."' %>
 end
 
 # Code to run in a worker right before it exits.
@@ -105,7 +105,7 @@ end
 #   puts 'On worker shutdown...'
 # end
 on_worker_shutdown do
-  <%= @out[:on_worker_shutdown] %>
+  <%= @out[:on_worker_shutdown] || 'puts "On worker shutdown..."' %>
 end
 
 # Code to run in the master right before a worker is started. The worker's
@@ -116,8 +116,8 @@ end
 # on_worker_fork do
 #   puts 'Before worker fork...'
 # end
-on_worker_fork do
-  <%= @out[:on_worker_fork] %>
+on_worker_fork do |worker_id|
+  <%= @out[:on_worker_fork] || 'puts "Before worker #{worker_id} fork..."' %>
 end
 
 # Code to run in the master after a worker has been started. The worker's
@@ -128,8 +128,8 @@ end
 # after_worker_fork do
 #   puts 'After worker fork...'
 # end
-after_worker_fork do
-  <%= @out[:after_worker_fork] %>
+after_worker_fork do |worker_id|
+  <%= @out[:after_worker_fork] || 'puts "After worker #{worker_id} fork..."' %>
 end
 
 # Change the default timeout of worker startup

--- a/templates/default/puma.rb.erb
+++ b/templates/default/puma.rb.erb
@@ -59,12 +59,79 @@ bind "tcp://127.0.0.1:3000"
 <% else %>
 bind "unix://<%= @deploy_dir %>/shared/sockets/puma.sock"
 <% end %>
+
+# Code to run before doing a restart. This code should
+# close log files, database connections, etc.
+#
+# This can be called multiple times to add code each time.
+#
+# on_restart do
+#   puts 'On restart...'
+# end
+on_restart do
+  <%= @out[:on_restart] %>
+end
+
 # === Cluster mode ===
 # How many worker processes to run.
 # The default is "0".
 workers <%= @out[:worker_processes] %>
 
+# Code to run immediately before the master starts workers.
+#
+# before_fork do
+#   puts "Starting workers..."
+# end
+before_fork do
+  <%= @out[:before_fork] %>
+end
+
+# Code to run in a worker before it starts serving requests.
+#
+# This is called everytime a worker is to be started.
+#
+# on_worker_boot do
+#   puts 'On worker boot...'
+# end
+on_worker_boot do
+  <%= @out[:on_worker_boot] %>
+end
+
+# Code to run in a worker right before it exits.
+#
+# This is called everytime a worker is to about to shutdown.
+#
+# on_worker_shutdown do
+#   puts 'On worker shutdown...'
+# end
+on_worker_shutdown do
+  <%= @out[:on_worker_shutdown] %>
+end
+
+# Code to run in the master right before a worker is started. The worker's
+# index is passed as an argument.
+#
+# This is called everytime a worker is to be started.
+#
+# on_worker_fork do
+#   puts 'Before worker fork...'
+# end
+on_worker_fork do
+  <%= @out[:on_worker_fork] %>
+end
+
+# Code to run in the master after a worker has been started. The worker's
+# index is passed as an argument.
+#
+# This is called everytime a worker is to be started.
+#
+# after_worker_fork do
+#   puts 'After worker fork...'
+# end
+after_worker_fork do
+  <%= @out[:after_worker_fork] %>
+end
+
 # Change the default timeout of worker startup
 # The default is 60
 worker_timeout <%= @out[:timeout] %>
-

--- a/test/integration/all_options/serverspec/all_options_spec.rb
+++ b/test/integration/all_options/serverspec/all_options_spec.rb
@@ -103,7 +103,6 @@ describe 'opsworks_ruby::configure' do
       its(:content) { should include 'ENV[\'HOME\'] = "/home/deploy"' }
       its(:content) { should include 'ENV[\'USER\'] = "deploy"' }
       its(:content) { should include 'PID_PATH="/run/lock/dummy_project/puma.pid"' }
-      its(:content) { should include 'def puma_running?' }
     end
   end
 

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -89,7 +89,6 @@ describe 'opsworks_ruby::configure' do
       its(:content) { should include 'ENV[\'HOME\'] = "/home/deploy"' }
       its(:content) { should include 'ENV[\'USER\'] = "deploy"' }
       its(:content) { should include 'PID_PATH="/run/lock/dummy_project/puma.pid"' }
-      its(:content) { should include 'def puma_running?' }
     end
   end
 

--- a/test/integration/http_unicorn_apache_hanami_resque/serverspec/http_unicorn_apache_hanami_resque_spec.rb
+++ b/test/integration/http_unicorn_apache_hanami_resque/serverspec/http_unicorn_apache_hanami_resque_spec.rb
@@ -90,7 +90,6 @@ describe 'opsworks_ruby::configure' do
       its(:content) { should include 'ENV[\'HOME\'] = "/home/deploy"' }
       its(:content) { should include 'ENV[\'USER\'] = "deploy"' }
       its(:content) { should include 'PID_PATH="/run/lock/dummy_project/unicorn.pid"' }
-      its(:content) { should include 'def unicorn_running?' }
     end
   end
 

--- a/test/integration/maximum_override/serverspec/maximum_override_spec.rb
+++ b/test/integration/maximum_override/serverspec/maximum_override_spec.rb
@@ -160,7 +160,6 @@ describe 'opsworks_ruby::configure' do
         its(:content) { should include 'ENV[\'HOME\'] = "/home/deploy"' }
         its(:content) { should include 'ENV[\'USER\'] = "deploy"' }
         its(:content) { should include 'PID_PATH="/run/lock/yet_another_project/unicorn.pid"' }
-        its(:content) { should include 'def unicorn_running?' }
       end
     end
   end

--- a/test/integration/s3_thin_nginx_padrino_delayed_job/serverspec/s3_thin_nginx_padrino_delayed_job_spec.rb
+++ b/test/integration/s3_thin_nginx_padrino_delayed_job/serverspec/s3_thin_nginx_padrino_delayed_job_spec.rb
@@ -62,7 +62,6 @@ describe 'opsworks_ruby::configure' do
       its(:content) { should include 'ENV[\'HOME\'] = "/home/deploy"' }
       its(:content) { should include 'ENV[\'USER\'] = "deploy"' }
       its(:content) { should include 'PID_PATH="/run/lock/dummy_project/thin.pid"' }
-      its(:content) { should include 'def thin_running?' }
     end
   end
 


### PR DESCRIPTION
The standard appserver service script current performs a stop-start cycle at the end of a deploy to load new code.  This is a bit problematic in production environments.  The appserver 'stop' closes the socket that nginx communicates with, which causes it to immediately return 502 responses.  This will continue until the appserver boot is completed and a new socket is established.  The net result is that requests to the application during the stop-start cycle will be lost.

Puma provides a facility to avoid this problem by issuing a 'restart' instead.  This keeps the socket open and reloads the code.  This causes requests that are received during the restart to hang until the app server finishes booting. 

Puma also provides several hooks for various events that occur during the worker / thread lifecycle that can be used to execute custom code.  For example, these hooks can be used to fine-tune what actions are taken before / after forking a new worker.

This PR does several things related to Puma configurations.

1. sets up an attribute (`node['deploy'][app]['appserver']['after_deploy']`) that can be used to control what kind of restart to perform.  The default is a `stop-start`, which is the current behavior.
2. Adds attributes for each of the puma hooks
3. Modifies the rendered appserver.service script to add an action for 'stop-start', and also remove unnecessary references to the type of adapter

Note: there is an unrelated change to force the dependency on apt < 7.0.0 because that version is not compatible with Chef 12 and breaks the build.  See https://github.com/ajgon/opsworks_ruby/issues/151
