### PR TITLE
fix: add Apache 2.4's "Require all granted" to apache2+passenger config

### DIFF
--- a/templates/default/appserver.apache2.passenger.conf.erb
+++ b/templates/default/appserver.apache2.passenger.conf.erb
@@ -69,6 +69,7 @@ SSLStaplingCache "shmcb:logs/stapling-cache(150000)"
   DocumentRoot <%= File.join(@deploy_dir, 'current', 'public') %>
 
   <Directory <%= File.join(@deploy_dir, 'current') %>>
+    Require all granted
     Options FollowSymLinks
     AllowOverride None
     Order allow,deny


### PR DESCRIPTION
fix #170 