### PR TITLE
Add X-Content-Type-Options=nosniff to assets 

### DIFF
--- a/templates/default/appserver.nginx.conf.erb
+++ b/templates/default/appserver.nginx.conf.erb
@@ -30,6 +30,7 @@ server {
     add_header Access-Control-Allow-Origin "$http_origin";
     add_header Access-Control-Allow-Methods 'GET, PUT, POST, DELETE';
     add_header Access-Control-Expose-Headers ETag;
+    add_header X-Content-Type-Options nosniff;
   }
 
   location @<%= @name %> {


### PR DESCRIPTION
During a routine security scan, a recommendation was made to add the `X-Content-Type-Options=nosniff` header for files served from assets.  This requires a change to nginx configs.

