### PR TITLE
feat(db): Added aurora-postgres as an accepted engine for Postgres adapter

### DIFF
--- a/libraries/drivers_db_postgresql.rb
+++ b/libraries/drivers_db_postgresql.rb
@@ -4,7 +4,7 @@ module Drivers
   module Db
     class Postgresql < Base
       adapter :postgresql
-      allowed_engines :postgres, :postgresql
+      allowed_engines :postgres, :postgresql, 'aurora-postresql'.to_sym
       packages debian: 'libpq-dev', rhel: 'postgresql96-devel'
     end
   end


### PR DESCRIPTION
Addresses issue #182. When an Aurora Postgres RDS resource is registered with a stack, it passes `aurora-postgresql` as the engine. Modified the `drivers_db_postgresql.rb` to accept this value.