### PR TITLE
Config bind

### DIFF
--- a/docs/source/attributes.rst
+++ b/docs/source/attributes.rst
@@ -433,7 +433,7 @@ appserver
 - ``app['appserver']['port']``
 
   - **Default:** None
-  - Bind the appserver to a port on 127.0.0.1.  This is
+  - Bind the appserver to a port on 0.0.0.0.  This is
     useful for serving the application directly from the appserver without a web
     server middleware or separating the web server into its own container or server.
 

--- a/docs/source/attributes.rst
+++ b/docs/source/attributes.rst
@@ -430,6 +430,13 @@ appserver
     these approaches varies between appservers.  See their documentation for more
     details.
 
+- ``app['appserver']['port']``
+
+  - **Default:** None
+  - Bind the appserver to a port on 127.0.0.1.  This is
+    useful for serving the application directly from the appserver without a web
+    server middleware or separating the web server into its own container or server.
+
 
 unicorn
 ^^^^^^^

--- a/libraries/drivers_appserver_puma.rb
+++ b/libraries/drivers_appserver_puma.rb
@@ -7,7 +7,7 @@ module Drivers
       allowed_engines :puma
       output filter: %i[log_requests preload_app thread_max thread_min timeout
                         on_restart worker_processes before_fork on_worker_boot on_worker_shutdown
-                        on_worker_fork after_worker_fork after_deploy]
+                        on_worker_fork after_worker_fork after_deploy port]
 
       def appserver_config
         'puma.rb'

--- a/libraries/drivers_appserver_thin.rb
+++ b/libraries/drivers_appserver_thin.rb
@@ -5,7 +5,8 @@ module Drivers
     class Thin < Drivers::Appserver::Base
       adapter :thin
       allowed_engines :thin
-      output filter: %i[max_connections max_persistent_connections timeout worker_processes]
+      output filter: %i[max_connections max_persistent_connections timeout worker_processes
+                        port]
 
       def appserver_config
         'thin.yml'

--- a/libraries/drivers_appserver_unicorn.rb
+++ b/libraries/drivers_appserver_unicorn.rb
@@ -7,6 +7,7 @@ module Drivers
       allowed_engines :unicorn
       output filter: %i[
         backlog delay preload_app tcp_nodelay tcp_nopush tries timeout worker_processes
+        port
       ]
 
       def appserver_config

--- a/templates/default/puma.rb.erb
+++ b/templates/default/puma.rb.erb
@@ -56,6 +56,8 @@ threads <%= @out[:thread_min] %>, <%= @out[:thread_max] %>
 # bind 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert'
 <% if @webserver == 'apache2' %>
 bind "tcp://127.0.0.1:3000"
+<% elsif @out[:port] %>
+bind "tcp://0.0.0.0:<%= @out[:port] %>"
 <% else %>
 bind "unix://<%= @deploy_dir %>/shared/sockets/puma.sock"
 <% end %>

--- a/templates/default/puma.rb.erb
+++ b/templates/default/puma.rb.erb
@@ -54,10 +54,10 @@ threads <%= @out[:thread_min] %>, <%= @out[:thread_max] %>
 # bind 'unix:///var/run/puma.sock'
 # bind 'unix:///var/run/puma.sock?umask=0777'
 # bind 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert'
-<% if @webserver == 'apache2' %>
-bind "tcp://127.0.0.1:3000"
-<% elsif @out[:port] %>
+<% if @out[:port] %>
 bind "tcp://0.0.0.0:<%= @out[:port] %>"
+<% elsif @webserver == 'apache2' %>
+bind "tcp://127.0.0.1:3000"
 <% else %>
 bind "unix://<%= @deploy_dir %>/shared/sockets/puma.sock"
 <% end %>

--- a/templates/default/thin.yml.erb
+++ b/templates/default/thin.yml.erb
@@ -11,12 +11,12 @@ servers: <%= @out[:worker_processes] %>
 threaded: true
 no-epoll: true
 daemonize: true
-<% if @webserver == 'apache2' %>
+<% if @out[:port] %>
+address: "0.0.0.0"
+port: <%= @out[:port] %>
+<% elsif @webserver == 'apache2' %>
 address: "127.0.0.1"
 port: 3000
-<% elsif @out[:port] %>
-address: "127.0.0.1"
-port: <%= @out[:port] %>
 <% else %>
 socket: "<%= @deploy_dir %>/shared/sockets/thin.sock"
 <% end %>

--- a/templates/default/thin.yml.erb
+++ b/templates/default/thin.yml.erb
@@ -14,6 +14,9 @@ daemonize: true
 <% if @webserver == 'apache2' %>
 address: "127.0.0.1"
 port: 3000
+<% elsif @out[:port] %>
+address: "127.0.0.1"
+port: <%= @out[:port] %>
 <% else %>
 socket: "<%= @deploy_dir %>/shared/sockets/thin.sock"
 <% end %>

--- a/templates/default/unicorn.conf.erb
+++ b/templates/default/unicorn.conf.erb
@@ -3,10 +3,10 @@ worker_processes <%= @out[:worker_processes] %>
 user "<%= node['deployer']['user'] %>"
 
 working_directory "<%= @deploy_dir %>/current"
-<% if @webserver == 'apache2' %>
+<% if @out[:port] %>
+listen "0.0.0.0:<%= @out[:port] %>",
+<% elsif @webserver == 'apache2' %>
 listen "127.0.0.1:3000",
-<% elsif @out[:port] %>
-listen "127.0.0.1:<%= @out[:port] %>",
 <% else %>
 listen "<%= @deploy_dir %>/shared/sockets/unicorn.sock",
 <% end %>

--- a/templates/default/unicorn.conf.erb
+++ b/templates/default/unicorn.conf.erb
@@ -5,6 +5,8 @@ user "<%= node['deployer']['user'] %>"
 working_directory "<%= @deploy_dir %>/current"
 <% if @webserver == 'apache2' %>
 listen "127.0.0.1:3000",
+<% elsif @out[:port] %>
+listen "127.0.0.1:<%= @out[:port] %>",
 <% else %>
 listen "<%= @deploy_dir %>/shared/sockets/unicorn.sock",
 <% end %>


### PR DESCRIPTION
this will allow people to separate out the appserver into its own container or server from the web server. Useful when there are compliance rules to separate these layers. Or if there is no benefit for a web server like when serving an api and routing on some other layer like the lb.
[issue](https://github.com/ajgon/opsworks_ruby/issues/162)