### PR TITLE
Fix typo for aurora postgresql

### DIFF
--- a/libraries/drivers_db_postgresql.rb
+++ b/libraries/drivers_db_postgresql.rb
@@ -4,7 +4,7 @@ module Drivers
   module Db
     class Postgresql < Base
       adapter :postgresql
-      allowed_engines :postgres, :postgresql, :'aurora-postresql'
+      allowed_engines :postgres, :postgresql, :'aurora-postgresql'
       packages debian: 'libpq-dev', rhel: 'postgresql96-devel'
     end
   end


### PR DESCRIPTION
There is a typo for Aurora PostgreSQL adapter. This PR fix it 😉 