### PR TITLE
Ensure shared/system dir is created

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -13,6 +13,7 @@ every_enabled_application do |application|
   create_deploy_dir(application, File.join('shared', 'log'))
   create_deploy_dir(application, File.join('shared', 'scripts'))
   create_deploy_dir(application, File.join('shared', 'sockets'))
+  create_deploy_dir(application, File.join('shared', 'system'))
   create_deploy_dir(application, File.join('shared', 'vendor/bundle'))
   create_dir("/run/lock/#{application['shortname']}")
 


### PR DESCRIPTION
This directory is symlinked by default here:

https://github.com/ajgon/opsworks_ruby/blob/6e2328941996d98316657d7a52c98de6982068a5/attributes/default.rb#L21

But the directory is never created and we're left with a broken symlink.