### PR TITLE
fix: register gpg public key for nginx on ubuntu18.04LTS

### DIFF
--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -62,6 +62,14 @@ apt_repository 'apache2' do
   only_if { node['defaults']['webserver']['use_apache2_ppa'] }
 end
 
+apt_repository 'nginx' do
+  uri        'http://nginx.org/packages/ubuntu/'
+  components ['nginx']
+  keyserver 'keyserver.ubuntu.com'
+  key 'ABF5BD827BD9BF62'
+  only_if { node['defaults']['webserver']['adapter'] == 'nginx' }
+end
+
 gem_package 'bundler' do
   action :install
 end


### PR DESCRIPTION
Fix following error.

```
================================================================================
Error executing action `run` on resource 'execute[apt-get -q update]'
================================================================================
 
Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '100'
---- Begin output of apt-get -q update ----
STDOUT: Hit:1 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu bionic InRelease
Hit:2 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu bionic-updates InRelease
Hit:3 http://ap-northeast-1.ec2.archive.ubuntu.com/ubuntu bionic-backports InRelease
Get:4 http://security.ubuntu.com/ubuntu bionic-security InRelease [83.2 kB]
Hit:5 http://ppa.launchpad.net/ondrej/apache2/ubuntu bionic InRelease
Hit:6 http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu bionic InRelease
Get:7 https://nginx.org/packages/ubuntu bionic InRelease [2844 B]
Err:7 https://nginx.org/packages/ubuntu bionic InRelease
The following signatures couldn't be verified because the public key is not available: NO_PUBKEY ABF5BD827BD9BF62
Reading package lists...
STDERR: W: GPG error: https://nginx.org/packages/ubuntu bionic InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY ABF5BD827BD9BF62
E: The repository 'https://nginx.org/packages/ubuntu bionic InRelease' is not signed.
---- End output of apt-get -q update ----
```