### PR TITLE
Serve packs w/ ACAO

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -99,6 +99,8 @@ default['defaults']['webserver']['remove_default_sites'] = %w[
   default default.conf 000-default 000-default.conf default-ssl default-ssl.conf
 ]
 default['defaults']['webserver']['force_ssl'] = false
+default['defaults']['webserver']['acao_packs'] = false
+default['defaults']['webserver']['acao_packs_domain'] = '*'
 
 ## apache2
 

--- a/templates/default/appserver.apache2.passenger.conf.erb
+++ b/templates/default/appserver.apache2.passenger.conf.erb
@@ -49,6 +49,17 @@ Header always unset "X-Powered-By"
     Header set X-Content-Type-Options "nosniff"
     </Location>
 
+  # Enable webpack serving
+  <Location "/packs/">
+    ExpiresActive on
+
+    Header set Cache-Control "public"
+    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Methods "GET, PUT, POST, DELETE"
+    Header set Access-Control-Expose-Headers "ETag"
+    Header set X-Content-Type-Options "nosniff"
+    </Location>
+
 <% if @appserver_config[:max_pool_size] -%>
   PassengerMaxPoolSize <%= @appserver_config[:max_pool_size] %>
 <% end %>
@@ -131,6 +142,17 @@ SSLStaplingCache "shmcb:logs/stapling-cache(150000)"
     Header set Access-Control-Expose-Headers "ETag"
     Header set X-Content-Type-Options "nosniff"
   </Location>
+
+  # Enable webpack serving
+  <Location "/packs/">
+    ExpiresActive on
+
+    Header set Cache-Control "public"
+    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Methods "GET, PUT, POST, DELETE"
+    Header set Access-Control-Expose-Headers "ETag"
+    Header set X-Content-Type-Options "nosniff"
+    </Location>
 
 <% if @appserver_config[:max_pool_size] -%>
   PassengerMaxPoolSize <%= @appserver_config[:max_pool_size] %>

--- a/templates/default/appserver.apache2.passenger.conf.erb
+++ b/templates/default/appserver.apache2.passenger.conf.erb
@@ -49,16 +49,18 @@ Header always unset "X-Powered-By"
     Header set X-Content-Type-Options "nosniff"
     </Location>
 
+<% if @out[:acao_packs] %>
   # Enable webpack serving
   <Location "/packs/">
     ExpiresActive on
 
     Header set Cache-Control "public"
-    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Origin "<%= @out[:acao_packs_origin] %>"
     Header set Access-Control-Allow-Methods "GET, PUT, POST, DELETE"
     Header set Access-Control-Expose-Headers "ETag"
     Header set X-Content-Type-Options "nosniff"
     </Location>
+<% end %>
 
 <% if @appserver_config[:max_pool_size] -%>
   PassengerMaxPoolSize <%= @appserver_config[:max_pool_size] %>
@@ -143,16 +145,18 @@ SSLStaplingCache "shmcb:logs/stapling-cache(150000)"
     Header set X-Content-Type-Options "nosniff"
   </Location>
 
+<% if @out[:acao_packs] %>
   # Enable webpack serving
   <Location "/packs/">
     ExpiresActive on
 
     Header set Cache-Control "public"
-    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Origin "<%= @out[:acao_packs_origin] %>"
     Header set Access-Control-Allow-Methods "GET, PUT, POST, DELETE"
     Header set Access-Control-Expose-Headers "ETag"
     Header set X-Content-Type-Options "nosniff"
     </Location>
+<% end %>
 
 <% if @appserver_config[:max_pool_size] -%>
   PassengerMaxPoolSize <%= @appserver_config[:max_pool_size] %>

--- a/templates/default/appserver.apache2.upstream.conf.erb
+++ b/templates/default/appserver.apache2.upstream.conf.erb
@@ -46,6 +46,19 @@ Listen <%= @out[:port] %>
     Header set X-Content-Type-Options "nosniff"
   </Location>
 
+  <% if @out[:acao_packs] %>
+  # Enable webpack serving
+  <Location "/packs/">
+    ExpiresActive on
+
+    Header set Cache-Control "public"
+    Header set Access-Control-Allow-Origin "<%= @out[:acao_packs_origin] %>"
+    Header set Access-Control-Allow-Methods "GET, PUT, POST, DELETE"
+    Header set Access-Control-Expose-Headers "ETag"
+    Header set X-Content-Type-Options "nosniff"
+    </Location>
+<% end %>
+
   RewriteEngine on
 
   <Proxy balancer://<%= upstream %>>
@@ -131,6 +144,19 @@ SSLStaplingCache "shmcb:logs/stapling-cache(150000)"
     Header set Access-Control-Expose-Headers "ETag"
     Header set X-Content-Type-Options "nosniff"
   </Location>
+
+  <% if @out[:acao_packs] %>
+  # Enable webpack serving
+  <Location "/packs/">
+    ExpiresActive on
+
+    Header set Cache-Control "public"
+    Header set Access-Control-Allow-Origin "<%= @out[:acao_packs_origin] %>"
+    Header set Access-Control-Allow-Methods "GET, PUT, POST, DELETE"
+    Header set Access-Control-Expose-Headers "ETag"
+    Header set X-Content-Type-Options "nosniff"
+    </Location>
+<% end %>
 
   RewriteEngine on
 

--- a/templates/default/appserver.nginx.conf.erb
+++ b/templates/default/appserver.nginx.conf.erb
@@ -42,6 +42,18 @@ server {
     add_header X-Content-Type-Options nosniff;
   }
 
+<% if @out[:acao_packs] %>
+    location ^~ /packs/ {
+    gzip_static on;
+    expires max;
+    add_header Cache-Control public;
+    add_header Access-Control-Allow-Origin "$http_origin";
+    add_header Access-Control-Allow-Methods 'GET, PUT, POST, DELETE';
+    add_header Access-Control-Expose-Headers ETag;
+    add_header X-Content-Type-Options nosniff;
+  }
+  <% end %>
+
   location @<%= @name %> {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
@@ -139,6 +151,18 @@ server {
     add_header Access-Control-Allow-Methods 'GET, PUT, POST, DELETE';
     add_header Access-Control-Expose-Headers ETag;
   }
+
+  <% if @out[:acao_packs] %>
+    location ^~ /packs/ {
+    gzip_static on;
+    expires max;
+    add_header Cache-Control public;
+    add_header Access-Control-Allow-Origin "$http_origin";
+    add_header Access-Control-Allow-Methods 'GET, PUT, POST, DELETE';
+    add_header Access-Control-Expose-Headers ETag;
+  }
+  <% end %>
+
 
   location @<%= @name %> {
     proxy_set_header X-Forwarded-Proto https;


### PR DESCRIPTION
This PR copies the `/assets/` location instruction block for the `/packs/` folder, ensuring that they're also served with ACAO for all origins.