### PR TITLE
Feature/ssl conf

### DIFF
--- a/libraries/drivers_dsl_output.rb
+++ b/libraries/drivers_dsl_output.rb
@@ -2,6 +2,22 @@
 
 module Drivers
   module Dsl
+    # Generates output for template consumption from OpsWorks Config JSON.
+    #
+    # Each driver namespace (webserver, appserver, framework etc.) can have it's own set of attributes which can be
+    # set in OpsWorks Config JSON - for example: config['deploy']['appname']['webserver']['force_ssl'].
+    #
+    # To consume, add an output call to the class definition:
+    # <tt>
+    # class ::Drivers::Webserver::Apache < ::Drivers::Webserver::Base
+    #   # Filtering the output contents (recommended).
+    #   output filter:  %i[dhparams keepalive_timeout]
+    #   # Without filtering the output contents.
+    #   output
+    # end
+    # </tt>
+    #
+    # Output hashes should only include values that can be configured with JSON.
     module Output
       def self.included(klass)
         klass.instance_eval do

--- a/libraries/drivers_webserver_apache2.rb
+++ b/libraries/drivers_webserver_apache2.rb
@@ -43,9 +43,7 @@ module Drivers
       def configure
         define_service
         add_ssl_directory
-        add_ssl_item(:private_key)
-        add_ssl_item(:certificate)
-        add_ssl_item(:chain)
+        %i[private_key certificate chain].each(&method(:add_ssl_item))
         add_dhparams
 
         remove_defaults

--- a/libraries/drivers_webserver_base.rb
+++ b/libraries/drivers_webserver_base.rb
@@ -2,7 +2,7 @@
 
 module Drivers
   module Webserver
-    class Base < Drivers::Base
+    class Base < Drivers::Base # rubocop:disable ClassLength
       include Drivers::Dsl::Logrotate
       include Drivers::Dsl::Notifies
       include Drivers::Dsl::Output
@@ -36,6 +36,10 @@ module Drivers
         raise NotImplementedError
       end
 
+      def ssl_cert_dir
+        "#{conf_dir}/ssl"
+      end
+
       def define_service(default_action = :nothing)
         context.service service_name do
           supports status: true, restart: true, reload: true
@@ -49,7 +53,7 @@ module Drivers
 
         extensions = { private_key: 'key', certificate: 'crt', chain: 'ca' }
 
-        notifying_template "#{conf_dir}/ssl/#{app[:domains].first}.#{extensions[name]}" do
+        notifying_template "#{ssl_cert_dir}/#{app[:domains].first}.#{extensions[name]}" do
           owner 'root'
           group 'root'
           mode name == :private_key ? '0600' : '0644'
@@ -59,7 +63,7 @@ module Drivers
       end
 
       def add_ssl_directory
-        context.directory "#{conf_dir}/ssl" do
+        context.directory ssl_cert_dir do
           owner 'root'
           group 'root'
           mode '0700'
@@ -82,7 +86,8 @@ module Drivers
       def add_appserver_config
         a = Drivers::Appserver::Factory.build(context, app)
         opts = { application: app, deploy_dir: deploy_dir(app), out: out, conf_dir: conf_dir, adapter: adapter,
-                 name: a.adapter, deploy_env: deploy_env, appserver_config: a.webserver_config_params }
+                 name: a.adapter, deploy_env: deploy_env, appserver_config: a.webserver_config_params,
+                 ssl_cert_dir: ssl_cert_dir }
         return unless Drivers::Appserver::Base.adapters.include?(opts[:name])
 
         generate_appserver_config(opts, site_config_template(opts[:name]), site_config_template_cookbook)

--- a/templates/default/appserver.apache2.passenger.conf.erb
+++ b/templates/default/appserver.apache2.passenger.conf.erb
@@ -91,10 +91,10 @@ SSLStaplingCache "shmcb:logs/stapling-cache(150000)"
 
   SSLEngine on
   SSLProxyEngine on
-  SSLCertificateFile /etc/apache2/ssl/<%= @application[:domains].first %>.crt
-  SSLCertificateKeyFile /etc/apache2/ssl/<%= @application[:domains].first %>.key
+  SSLCertificateFile <%= @ssl_cert_dir %>/<%= @application[:domains].first %>.crt
+  SSLCertificateKeyFile <%= @ssl_cert_dir %>/<%= @application[:domains].first %>.key
   <% if @application[:ssl_configuration][:chain] -%>
-  SSLCACertificateFile /etc/apache2/ssl/<%= @application[:domains].first %>.ca
+  SSLCACertificateFile <%= @ssl_cert_dir %>/<%= @application[:domains].first %>.ca
   <% end %>
   SetEnvIf User-Agent ".*MSIE.*" nokeepalive ssl-unclean-shutdown downgrade-1.0 force-response-1.0
 
@@ -144,6 +144,8 @@ SSLStaplingCache "shmcb:logs/stapling-cache(150000)"
     PassengerBaseURI <%= @appserver_config[:mount_point] %>
     PassengerAppRoot <%= File.join(@deploy_dir, 'current') %>
   </Location>
+
+  RequestHeader set X-Forwarded-Proto "https"
 
   RewriteEngine on
 

--- a/templates/default/appserver.apache2.upstream.conf.erb
+++ b/templates/default/appserver.apache2.upstream.conf.erb
@@ -91,10 +91,10 @@ SSLStaplingCache "shmcb:logs/stapling-cache(150000)"
 
   SSLEngine on
   SSLProxyEngine on
-  SSLCertificateFile /etc/apache2/ssl/<%= @application[:domains].first %>.crt
-  SSLCertificateKeyFile /etc/apache2/ssl/<%= @application[:domains].first %>.key
+  SSLCertificateFile <%= @ssl_cert_dir %>/<%= @application[:domains].first %>.crt
+  SSLCertificateKeyFile <%= @ssl_cert_dir %>/<%= @application[:domains].first %>.key
   <% if @application[:ssl_configuration][:chain] -%>
-  SSLCACertificateFile /etc/apache2/ssl/<%= @application[:domains].first %>.ca
+  SSLCACertificateFile <%= @ssl_cert_dir %>/<%= @application[:domains].first %>.ca
   <% end %>
   SetEnvIf User-Agent ".*MSIE.*" nokeepalive ssl-unclean-shutdown downgrade-1.0 force-response-1.0
 

--- a/templates/default/appserver.nginx.conf.erb
+++ b/templates/default/appserver.nginx.conf.erb
@@ -86,10 +86,10 @@ server {
   error_log <%= @out[:log_dir] %>/<%= @application[:domains].first %>-ssl.error.log <%= @out[:log_level] %>;
 
   ssl on;
-  ssl_certificate /etc/nginx/ssl/<%= @application[:domains].first %>.crt;
-  ssl_certificate_key /etc/nginx/ssl/<%= @application[:domains].first %>.key;
+  ssl_certificate <%= @ssl_cert_dir %>/<%= @application[:domains].first %>.crt;
+  ssl_certificate_key <%= @ssl_cert_dir %>/<%= @application[:domains].first %>.key;
   <% if @application[:ssl_configuration][:chain] -%>
-  ssl_client_certificate /etc/nginx/ssl/<%= @application[:domains].first %>.ca;
+  ssl_client_certificate <%= @ssl_cert_dir %>/<%= @application[:domains].first %>.ca;
   <% end -%>
 
   <% if @out[:ssl_for_legacy_browsers] -%>
@@ -113,7 +113,7 @@ server {
   ssl_stapling_verify on;
   <% end -%>
   <% if @out[:dhparams].present? -%>
-  ssl_dhparam /etc/nginx/ssl/<%= @application[:domains].first %>.dhparams.pem;
+  ssl_dhparam <%= @ssl_cert_dir %>/<%= @application[:domains].first %>.dhparams.pem;
   <% end -%>
 
   root <%= File.join(@deploy_dir, 'current', 'public') %>;


### PR DESCRIPTION
This PR makes the following changes, fixes #205.

- Adds `ssl_cert_dir` to the Apache 2 webserver output.
- Updates the Passenger and Upstream versions of the Apache 2 template to use `ssl_cert_dir` for the SSL certificate paths.
- Adds the `X-Forwarded-Proto https` header to the Passenger template.
