### PR TITLE
Compare lockfiles instead of main Gemfile

### DIFF
--- a/templates/default/appserver.service.erb
+++ b/templates/default/appserver.service.erb
@@ -31,11 +31,12 @@ def running?
 end
 
 def different_gemfile?
-  if File.exists?("#{ROOT_PATH}/current/Gemfile")
+  current_gemfile = "#{ROOT_PATH}/current/Gemfile.lock"
+  if File.exists?(current_gemfile)
     dir = Dir["#{ROOT_PATH}/releases/*"]
     previous_release_path = dir.sort[dir.size-2]
-    if !previous_release_path.nil? && File.exists?("#{previous_release_path}/Gemfile")
-      return Digest::MD5.hexdigest(File.read("#{ROOT_PATH}/current/Gemfile")) != Digest::MD5.hexdigest(File.read("#{previous_release_path}/Gemfile"))
+    if !previous_release_path.nil? && File.exists?("#{previous_release_path}/Gemfile.lock")
+      return Digest::MD5.hexdigest(File.read(current_gemfile)) != Digest::MD5.hexdigest(File.read("#{previous_release_path}/Gemfile.lock"))
     end
   end
   false


### PR DESCRIPTION
We encountered an issue with the combined configuration of using a `unicorn` appserver and `clean-restart` as the after-deploy action.

To reproduce, we ran `bundle update` on a gem that changed the patch level of a gem without changing the contents of the `Gemfile`.  By using the `Gemfile.lock` instead to determine whether installed library changes have occurred, we managed the mitigate the issue.