### PR TITLE
feat(setup): added support for webpacker

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,7 +14,9 @@ default['nginx']['source']['modules'] = %w[
   nginx::http_stub_status_module
 ]
 
-default['nodejs']['version'] = '8.11.1'
+# nodejs
+default['nodejs']['repo'] = 'https://deb.nodesource.com/node_10.x'
+default['nodejs']['version'] = '10.15.3'
 
 default['deploy']['timeout'] = 600
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,6 +14,8 @@ default['nginx']['source']['modules'] = %w[
   nginx::http_stub_status_module
 ]
 
+default['nodejs']['version'] = '8.11.1'
+
 default['deploy']['timeout'] = 600
 
 # global
@@ -23,11 +25,14 @@ default['defaults']['global']['symlinks'] = {
   'assets' => 'public/assets',
   'cache' => 'tmp/cache',
   'pids' => 'tmp/pids',
-  'log' => 'log'
+  'log' => 'log',
+  'node_modules' => 'node_modules',
+  'packs' => 'public/packs'
 }
 default['defaults']['global']['create_dirs_before_symlink'] =
-  %w[tmp public config ../../shared/cache ../../shared/assets]
-default['defaults']['global']['purge_before_symlink'] = %w[log tmp/cache tmp/pids public/system public/assets]
+  %w[tmp public config ../../shared/cache ../../shared/assets ../../shared/node_modules ../../shared/packs]
+default['defaults']['global']['purge_before_symlink'] =
+  %w[log tmp/cache tmp/pids public/system public/assets node_modules public/packs]
 default['defaults']['global']['rollback_on_error'] = true
 default['defaults']['global']['logrotate_rotate'] = 30
 default['defaults']['global']['logrotate_frequency'] = 'daily'

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,6 +15,8 @@ depends 'logrotate'
 depends 'ruby-ng'
 depends 's3_file'
 depends 'sudo'
+depends 'nodejs'
+depends 'yarn'
 
 # indirect dependency, but breaks against the chef_version if updated to 3.1.0
 depends 'seven_zip', '~> 2.0'

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -44,6 +44,10 @@ if node['platform_family'] == 'debian'
   end
 end
 
+# NodeJS and Yarn
+include_recipe 'nodejs'
+include_recipe 'yarn'
+
 # Ruby and bundler
 if node['platform_family'] == 'debian'
   node.default['ruby-ng']['ruby_version'] = node['ruby-version']

--- a/spec/unit/recipes/deploy_spec.rb
+++ b/spec/unit/recipes/deploy_spec.rb
@@ -98,10 +98,14 @@ describe 'opsworks_ruby::deploy' do
           'cache' => 'tmp/cache',
           'pids' => 'tmp/pids',
           'log' => 'log',
+          'node_modules' => 'node_modules',
+          'packs' => 'public/packs',
           'test' => 'public/test'
         },
-        'create_dirs_before_symlink' => %w[tmp public config ../../shared/cache ../../shared/assets ../shared/test],
-        'purge_before_symlink' => %w[log tmp/cache tmp/pids public/system public/assets public/test]
+        'create_dirs_before_symlink' => %w[tmp public config ../../shared/cache ../../shared/assets
+                                           ../../shared/node_modules ../../shared/packs ../shared/test],
+        'purge_before_symlink' => %w[log tmp/cache tmp/pids public/system public/assets node_modules public/packs
+                                     public/test]
       )
 
       expect(chef_run).to disable_logrotate_app('rails')


### PR DESCRIPTION
Rails 5.2 adds webpacker support by default.  This PR adds necessary functionality to support webpacker.

# Features
* Significantly decrease asset compilation time for webpacker by adding symlinks for node_modules and public/packs
* Install Node.js 10.15.3 LTS
* Install latest Yarn