### PR TITLE
Fix quieting and stopping sidekiq

### DIFF
--- a/spec/unit/recipes/configure_spec.rb
+++ b/spec/unit/recipes/configure_spec.rb
@@ -385,8 +385,9 @@ describe 'opsworks_ruby::configure' do
         expect(chef_run_rhel)
           .to render_file("/etc/monit.d/sidekiq_#{aws_opsworks_app['shortname']}.monitrc")
           .with_content(
-            'stop program = "/bin/su - deploy -c \"ps -ax | grep \'bundle exec sidekiq\' | grep sidekiq_1.yml | ' \
-            'grep -v grep | awk \'{print $1}\' | xargs kill\"" with timeout 8 seconds'
+            'stop program = "/bin/su - deploy -c \'ps -ax | grep "bundle exec sidekiq" | grep sidekiq_1.yml | ' \
+            'grep -v grep | awk "{print \$1}" | xargs --no-run-if-empty pgrep -P | xargs --no-run-if-empty kill\'" ' \
+            'with timeout 8 seconds'
           )
         expect(chef_run_rhel)
           .to render_file("/etc/monit.d/sidekiq_#{aws_opsworks_app['shortname']}.monitrc")
@@ -403,8 +404,9 @@ describe 'opsworks_ruby::configure' do
         expect(chef_run_rhel)
           .to render_file("/etc/monit.d/sidekiq_#{aws_opsworks_app['shortname']}.monitrc")
           .with_content(
-            'stop program = "/bin/su - deploy -c \"ps -ax | grep \'bundle exec sidekiq\' | grep sidekiq_2.yml | ' \
-            'grep -v grep | awk \'{print $1}\' | xargs kill\"" with timeout 8 seconds'
+            'stop program = "/bin/su - deploy -c \'ps -ax | grep "bundle exec sidekiq" | grep sidekiq_2.yml | ' \
+            'grep -v grep | awk "{print \$1}" | xargs --no-run-if-empty pgrep -P | xargs --no-run-if-empty kill\'" ' \
+            'with timeout 8 seconds'
           )
         expect(chef_run_rhel)
           .to render_file("/etc/monit.d/sidekiq_#{aws_opsworks_app['shortname']}.monitrc")
@@ -431,8 +433,9 @@ describe 'opsworks_ruby::configure' do
         expect(chef_run)
           .to render_file("/etc/monit/conf.d/sidekiq_#{aws_opsworks_app['shortname']}.monitrc")
           .with_content(
-            'stop program = "/bin/su - deploy -c \"ps -ax | grep \'bundle exec sidekiq\' | grep sidekiq_1.yml | ' \
-            'grep -v grep | awk \'{print $1}\' | xargs kill\"" with timeout 8 seconds'
+            'stop program = "/bin/su - deploy -c \'ps -ax | grep "bundle exec sidekiq" | grep sidekiq_1.yml | ' \
+            'grep -v grep | awk "{print \$1}" | xargs --no-run-if-empty pgrep -P | xargs --no-run-if-empty kill\'" ' \
+            'with timeout 8 seconds'
           )
         expect(chef_run)
           .to render_file("/etc/monit/conf.d/sidekiq_#{aws_opsworks_app['shortname']}.monitrc")
@@ -449,8 +452,9 @@ describe 'opsworks_ruby::configure' do
         expect(chef_run)
           .to render_file("/etc/monit/conf.d/sidekiq_#{aws_opsworks_app['shortname']}.monitrc")
           .with_content(
-            'stop program = "/bin/su - deploy -c \"ps -ax | grep \'bundle exec sidekiq\' | grep sidekiq_2.yml | ' \
-            'grep -v grep | awk \'{print $1}\' | xargs kill\"" with timeout 8 seconds'
+            'stop program = "/bin/su - deploy -c \'ps -ax | grep "bundle exec sidekiq" | grep sidekiq_2.yml | ' \
+            'grep -v grep | awk "{print \$1}" | xargs --no-run-if-empty pgrep -P | xargs --no-run-if-empty kill\'" ' \
+            'with timeout 8 seconds'
           )
         expect(chef_run)
           .to render_file("/etc/monit/conf.d/sidekiq_#{aws_opsworks_app['shortname']}.monitrc")

--- a/spec/unit/recipes/shutdown_spec.rb
+++ b/spec/unit/recipes/shutdown_spec.rb
@@ -33,13 +33,15 @@ describe 'opsworks_ruby::shutdown' do
       expect(chef_run).to(
         run_execute(
           '/bin/su - deploy -c "ps -ax | grep \'bundle exec sidekiq\' | ' \
-          'grep sidekiq_1.yml | grep -v grep | awk \'{print $1}\' | xargs kill -TSTP"'
+          'grep sidekiq_1.yml | grep -v grep | awk \'{print \\$1}\' | ' \
+          'xargs --no-run-if-empty pgrep -P | xargs --no-run-if-empty kill -TSTP"'
         )
       )
       expect(chef_run).to(
         run_execute(
           '/bin/su - deploy -c "ps -ax | grep \'bundle exec sidekiq\' | ' \
-          'grep sidekiq_2.yml | grep -v grep | awk \'{print $1}\' | xargs kill -TSTP"'
+          'grep sidekiq_2.yml | grep -v grep | awk \'{print \\$1}\' | ' \
+          'xargs --no-run-if-empty pgrep -P | xargs --no-run-if-empty kill -TSTP"'
         )
       )
     end
@@ -48,13 +50,15 @@ describe 'opsworks_ruby::shutdown' do
       expect(chef_run).to(
         run_execute(
           'timeout 8 /bin/su - deploy -c "ps -ax | grep \'bundle exec sidekiq\' | ' \
-          'grep sidekiq_1.yml | grep -v grep | awk \'{print $1}\' | xargs kill -TERM"'
+          'grep sidekiq_1.yml | grep -v grep | awk \'{print \\$1}\' | ' \
+          'xargs --no-run-if-empty pgrep -P | xargs --no-run-if-empty kill"'
         )
       )
       expect(chef_run).to(
         run_execute(
           'timeout 8 /bin/su - deploy -c "ps -ax | grep \'bundle exec sidekiq\' | ' \
-          'grep sidekiq_2.yml | grep -v grep | awk \'{print $1}\' | xargs kill -TERM"'
+          'grep sidekiq_2.yml | grep -v grep | awk \'{print \\$1}\' | ' \
+          'xargs --no-run-if-empty pgrep -P | xargs --no-run-if-empty kill"'
         )
       )
     end

--- a/templates/default/sidekiq.monitrc.erb
+++ b/templates/default/sidekiq.monitrc.erb
@@ -7,7 +7,7 @@
 
     check process sidekiq_<%= identifier.to_s %> matching "bundle exec sidekiq.*/sidekiq_<%= n+1 %>.yml"
     start program = "/bin/su - <%= node['deployer']['user'] %> -c 'cd <%= File.join(@deploy_to, 'current') %> && <%= @environment.map { |k, v| "#{k}=\"#{v}\"" }.join(' ') %> bundle exec sidekiq -C <%= conf_file.to_s %><%= to_require.to_s %> <%= syslog.to_s %>'" with timeout 90 seconds
-    stop program = "/bin/su - <%= node['deployer']['user'] %> -c \"ps -ax | grep 'bundle exec sidekiq' | grep sidekiq_<%= n+1 %>.yml | grep -v grep | awk '{print $1}' | xargs kill\"" with timeout <%= timeout %> seconds
+    stop program = "/bin/su - <%= node['deployer']['user'] %> -c 'ps -ax | grep "bundle exec sidekiq" | grep sidekiq_<%= n+1 %>.yml | grep -v grep | awk "{print \$1}" | xargs --no-run-if-empty pgrep -P | xargs --no-run-if-empty kill'" with timeout <%= timeout %> seconds
     group sidekiq_<%= @application.to_s %>_group
 
 <% end %>


### PR DESCRIPTION
Without this change, I get the following error when running setup:

```
    [2019-05-07T22:49:06+00:00] ERROR: execute[/bin/su - deploy -c "ps -ax | grep 'bundle exec sidekiq' | grep sidekiq_1.yml | grep -v grep | awk '{print $1}' | xargs kill -TSTP"] (opsworks_ruby::deploy line 52) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '123'
    ---- Begin output of /bin/su - deploy -c "ps -ax | grep 'bundle exec sidekiq' | grep sidekiq_1.yml | grep -v grep | awk '{print $1}' | xargs kill -TSTP" ----
    STDOUT:
    STDERR: kill: invalid argument c

    Usage:
     kill [options] <pid> [...]

    Options:
     <pid> [...]            send signal to every <pid> listed
     -<signal>, -s, --signal <signal>
                        specify the <signal> to be sent
     -l, --list=[<signal>]  list all signal names, or convert one to a name
     -L, --table            list all signal names in a nice table

     -h, --help     display this help and exit
     -V, --version  output version information and exit

    For more details see kill(1).
    ---- End output of /bin/su - deploy -c "ps -ax | grep 'bundle exec sidekiq' | grep sidekiq_1.yml | grep -v grep | awk '{print $1}' | xargs kill -TSTP" ----
```

Just escaping the `$` wasn't enough -- that alone ends up piping the wrong PID to `kill`--it's the PID of a parent process.  We need to use that to get all child processes so that we can signal the right process.