### PR TITLE
fix(webserver): remove default nginx config from conf.d

### DIFF
--- a/libraries/drivers_webserver_nginx.rb
+++ b/libraries/drivers_webserver_nginx.rb
@@ -41,6 +41,7 @@ module Drivers
         add_ssl_item(:chain)
         add_dhparams
 
+        remove_defaults
         add_appserver_config
         enable_appserver_config
         super
@@ -58,6 +59,16 @@ module Drivers
       def service_name
         'nginx'
       end
+
+      private
+
+        def remove_defaults
+          conf_path = "#{conf_dir}/conf.d/default.conf"
+
+          notifying_file "#{conf_path}/sites-enabled/#{file}", :reload do
+            action :delete
+          end
+        end
     end
   end
 end

--- a/libraries/drivers_webserver_nginx.rb
+++ b/libraries/drivers_webserver_nginx.rb
@@ -63,9 +63,7 @@ module Drivers
       private
 
         def remove_defaults
-          conf_path = "#{conf_dir}/conf.d/default.conf"
-
-          notifying_file "#{conf_path}/sites-enabled/#{file}", :reload do
+          notifying_file "#{conf_dir}/conf.d/default.conf", :reload do
             action :delete
           end
         end

--- a/libraries/drivers_webserver_nginx.rb
+++ b/libraries/drivers_webserver_nginx.rb
@@ -62,11 +62,11 @@ module Drivers
 
       private
 
-        def remove_defaults
-          notifying_file "#{conf_dir}/conf.d/default.conf", :reload do
-            action :delete
-          end
+      def remove_defaults
+        notifying_file "#{conf_dir}/conf.d/default.conf", :reload do
+          action :delete
         end
+      end
     end
   end
 end


### PR DESCRIPTION
There is a default nginx server configuration in `/etc/nginx/conf.d/default.conf`.  It is acting as `default_server` instead of `/etc/nginx/sites-enabled/my-app.conf`.  This means the load balancers cannot connect to the app.

It's acting as the default server because it gets included first.
```
# /etc/nginx/nginx.conf

http {
  ...
  include /etc/nginx/conf.d/*.conf;
  include /etc/nginx/sites-enabled/*;
}
```

This PR simply removes that default server file.

Not sure why this suddenly started happening.  I noticed this after upgrading an older stack from opsworks_ruby 1.4 to 1.15.