### PR TITLE
added do_not_purge_before_symlink

### DIFF
--- a/docs/source/attributes.rst
+++ b/docs/source/attributes.rst
@@ -131,6 +131,14 @@ Global parameters apply to the whole application, and can be used by any section
   -  List of directories to be wiped out before symlinking. Paths are relative to ``release_path``.
      For example ``tmp`` becomes ``/srv/www/app_name/current/tmp``.
 
+- ``app['global']['do_not_purge_before_symlink']``
+
+  -  **Type:** array
+  -  **Default:** ``[]``
+  -  List of directories to exclude from the default list of directories to be purged. Paths are relative to ``release_path``.
+     For example ``tmp`` becomes ``/srv/www/app_name/current/tmp``.
+
+
 - ``app['global']['rollback_on_error']``
 
   -  **Type:** boolean

--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -43,7 +43,8 @@ every_enabled_application do |application|
     purge_before_symlink(
       (
         node['defaults']['global']['purge_before_symlink'] +
-        Array.wrap(globals(:purge_before_symlink, application['shortname']))
+        Array.wrap(globals(:purge_before_symlink, application['shortname'])) -
+        Array.wrap(globals(:do_not_purge_before_symlink, application['shortname']))
       ).uniq
     )
     symlink_before_migrate globals(:symlink_before_migrate, application['shortname'])

--- a/spec/fixtures/node.rb
+++ b/spec/fixtures/node.rb
@@ -14,6 +14,7 @@ DEFAULT_NODE = {
         environment: 'staging',
         create_dirs_before_symlink: %(../shared/test),
         purge_before_symlink: %w[public/test],
+        do_not_purge_before_symlink: %w[tmp/pids],
         symlinks: { 'test' => 'public/test' }
       },
       # database: {

--- a/spec/unit/recipes/deploy_spec.rb
+++ b/spec/unit/recipes/deploy_spec.rb
@@ -102,7 +102,7 @@ describe 'opsworks_ruby::deploy' do
         },
         'create_dirs_before_symlink' => %w[tmp public config ../../shared/cache ../../shared/assets
                                            ../shared/test],
-        'purge_before_symlink' => %w[log tmp/cache tmp/pids public/system public/assets public/test]
+        'purge_before_symlink' => %w[log tmp/cache public/system public/assets public/test]
       )
 
       expect(chef_run).to disable_logrotate_app('rails')
@@ -147,7 +147,7 @@ describe 'opsworks_ruby::deploy' do
           },
           'create_dirs_before_symlink' => %w[tmp public config ../../shared/cache ../../shared/assets
                                              ../../shared/node_modules ../../shared/packs ../shared/test],
-          'purge_before_symlink' => %w[log tmp/cache tmp/pids public/system public/assets node_modules public/packs
+          'purge_before_symlink' => %w[log tmp/cache public/system public/assets node_modules public/packs
                                        public/test]
         )
 


### PR DESCRIPTION
see issue #224 

This will allow a user to remove directories from the default list of directories that are purged.