### PR TITLE
Allow selection of cookbook for worker monitrc template.

### DIFF
--- a/docs/source/attributes.rst
+++ b/docs/source/attributes.rst
@@ -805,6 +805,11 @@ nginx
 worker
 ~~~~~~
 
+-  ``app['worker']['monit_template_cookbook']``
+
+  -  **Default** ``opsworks_ruby``
+  -  The name of the cookbook from which the worker monit template(s) will be drawn.
+
 sidekiq
 ^^^^^^^
 

--- a/libraries/drivers_worker_base.rb
+++ b/libraries/drivers_worker_base.rb
@@ -16,15 +16,21 @@ module Drivers
 
       def add_worker_monit
         opts = { application: app['shortname'], name: app['name'], out: out, deploy_to: deploy_dir(app),
-                 environment: environment, adapter: adapter, app_shortname: app['shortname'] }
+                 environment: environment, adapter: adapter, app_shortname: app['shortname'],
+                 source_cookbook: worker_monit_template_cookbook }
 
         context.template File.join(node['monit']['basedir'], "#{opts[:adapter]}_#{opts[:application]}.monitrc") do
           mode '0640'
           source "#{opts[:adapter]}.monitrc.erb"
+          cookbook opts[:source_cookbook].to_s
           variables opts
         end
 
         context.execute 'monit reload'
+      end
+
+      def worker_monit_template_cookbook
+        node['deploy'][app['shortname']][driver_type]['monit_template_cookbook'] || context.cookbook_name
       end
 
       def restart_monit


### PR DESCRIPTION
I had a need to modify the monitrc in a special case.

This PR adds `app['worker']['monit_template_cookbook']` with a default of `opsworks_ruby`.