### PR TITLE
Use revision-based deploy provider.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,6 +46,7 @@ default['defaults']['global']['logrotate_frequency'] = 'daily'
 default['defaults']['global']['logrotate_options'] = %w[
   missingok compress delaycompress notifempty copytruncate sharedscripts
 ]
+default['defaults']['global']['deploy_revision'] = false
 default['defaults']['global']['use_nodejs'] = false
 
 if node['use-nodejs']

--- a/docs/source/attributes.rst
+++ b/docs/source/attributes.rst
@@ -191,6 +191,15 @@ Global parameters apply to the whole application, and can be used by any section
      will result in the ``logrotate_app`` resource being invoked with the resource value ``cookbook 'my_cookbook'``.
   -  See Logrotate Attributes for more information on logrotate attribute precedence.
 
+- ``app['global']['deploy_revision']``
+
+  -  **Type:** boolean
+  -  **Default:** ``false``
+  -  When set to true, deployments will use the ``deploy_revision`` provider.
+     The name of a release sub-directory will use a revision identifier rather
+     than a timestamp.
+  -  See `the deploy_revision documentation`_ for more information.
+
 
 database
 ~~~~~~~~
@@ -893,6 +902,7 @@ shoryuken
 .. _app['appserver']['after_worker_fork']: https://github.com/puma/puma/blob/e4255d03fb57021c96f7d03a3784b21b6e85b35b/examples/config.rb#L150
 .. _Read more here.: https://weakdh.org/sysadmin.html
 .. _covered in this article: https://cipherli.st/
+.. _the deploy_revision documentation: https://docs-archive.chef.io/release/12-13/resource_deploy.html#deploy-revision
 .. |app['webserver']['limit_request_body']| replace:: ``app['webserver']['limit_request_body']``
 .. _app['webserver']['limit_request_body']: https://httpd.apache.org/docs/2.4/mod/core.html#limitrequestbody
 .. |app['webserver']['log_level']| replace:: ``app['webserver']['log_level']``

--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -21,11 +21,15 @@ every_enabled_application do |application|
 
   fire_hook(:before_deploy, items: databases + [source, framework, appserver, worker, webserver])
 
-  deploy_revision application['shortname'] do
+  deploy application['shortname'] do
     deploy_to deploy_dir(application)
     user node['deployer']['user'] || 'root'
     group www_group
     environment env_vars
+
+    if globals(:deploy_revision, application['shortname'])
+      provider Chef::Provider::Deploy::Revision
+    end
 
     if globals(:rollback_on_error, application['shortname']).nil?
       rollback_on_error node['defaults']['global']['rollback_on_error']

--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -21,7 +21,7 @@ every_enabled_application do |application|
 
   fire_hook(:before_deploy, items: databases + [source, framework, appserver, worker, webserver])
 
-  deploy application['shortname'] do
+  deploy_revision application['shortname'] do
     deploy_to deploy_dir(application)
     user node['deployer']['user'] || 'root'
     group www_group

--- a/recipes/undeploy.rb
+++ b/recipes/undeploy.rb
@@ -16,10 +16,14 @@ every_enabled_application do |application|
 
   fire_hook(:before_undeploy, items: databases + [source, framework, appserver, worker, webserver])
 
-  deploy_revision application['shortname'] do
+  deploy application['shortname'] do
     deploy_to deploy_dir(application)
     user node['deployer']['user'] || 'root'
     group www_group
+
+    if globals(:deploy_revision, application['shortname'])
+      provider Chef::Provider::Deploy::Revision
+    end
 
     [appserver, webserver].each do |server|
       server.notifies[:undeploy].each do |config|

--- a/recipes/undeploy.rb
+++ b/recipes/undeploy.rb
@@ -16,7 +16,7 @@ every_enabled_application do |application|
 
   fire_hook(:before_undeploy, items: databases + [source, framework, appserver, worker, webserver])
 
-  deploy application['shortname'] do
+  deploy_revision application['shortname'] do
     deploy_to deploy_dir(application)
     user node['deployer']['user'] || 'root'
     group www_group

--- a/spec/fixtures/aws_opsworks_app.rb
+++ b/spec/fixtures/aws_opsworks_app.rb
@@ -6,7 +6,7 @@ def aws_opsworks_app(override = {})
     app_id: '3aef37c1-7e2b-4255-bbf1-03e06f07701a',
     app_source: {
       password: '3aa161d358a167204502',
-      revision: 'master',
+      revision: 'dbfbd8dbc989e3a4465504d83fafc5ec7f204e7f',
       ssh_key: '--- SSH KEY ---',
       type: 'git',
       url: 'git@git.example.com:repo/project.git',

--- a/spec/unit/recipes/deploy_spec.rb
+++ b/spec/unit/recipes/deploy_spec.rb
@@ -387,6 +387,7 @@ describe 'opsworks_ruby::deploy' do
         solo_node.set['lsb'] = node['lsb']
         solo_node.set['deploy'] = { 'a1' => {} }
         solo_node.set['deploy']['a1']['global']['deploy_dir'] = deploy_dir if deploy_dir
+        solo_node.set['deploy']['a1']['global']['deploy_revision'] = deploy_revision if deploy_revision
       end
     end
 
@@ -404,6 +405,14 @@ describe 'opsworks_ruby::deploy' do
         expect(chef_run).to create_template('/srv/www/a1/shared/config/database.yml')
         expect(chef_run).to create_template('/srv/www/a1/shared/config/puma.rb')
         expect(chef_run).to create_template('/srv/www/a1/shared/scripts/puma.service')
+      end
+    end
+
+    context 'when deploy_revision is true' do
+      let(:deploy_revision) { true }
+
+      it 'deploys a1 using a release subdirectory named by revision' do
+        expect(chef_run).to create_directory("/srv/www/a1/releases/dbfbd8dbc989e3a4465504d83fafc5ec7f204e7f")
       end
     end
 

--- a/templates/default/appserver.service.erb
+++ b/templates/default/appserver.service.erb
@@ -34,7 +34,8 @@ def different_gemfile?
   current_gemfile = "#{ROOT_PATH}/current/Gemfile.lock"
   if File.exists?(current_gemfile)
     dir = Dir["#{ROOT_PATH}/releases/*"]
-    previous_release_path = dir.sort[dir.size-2]
+    previous_release_path = dir.sort_by { |d| ::File.ctime(d) }[-2]
+
     if !previous_release_path.nil? && File.exists?("#{previous_release_path}/Gemfile.lock")
       return Digest::MD5.hexdigest(File.read(current_gemfile)) != Digest::MD5.hexdigest(File.read("#{previous_release_path}/Gemfile.lock"))
     end


### PR DESCRIPTION
The recommended deploy provider up until total deprecation was `deploy_revision` which uses git reference, rather than timestamp, for the path. It's not the default for historical reasons and ISTR wasn't even available until opsworks_ruby recently imported the deploy_resource code.

We'd found that the timestamped provider intermittently broke reproducible asset builds in our production cluster, in particular where Webpack output hash configurations were path-specific, since all the path slugs varied by a few seconds.

This is a simple-looking PR and already in production with us, but I'm aware it could be a major or breaking change for some folks.
