### PR TITLE
Fix fullstaq key url

### DIFF
--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -101,7 +101,7 @@ if node['ruby-provider'] == 'fullstaq'
       baseurl 'https://yum.fullstaqruby.org/centos-7/$basearch'
       enabled true
       gpgcheck false
-      gpgkey 'https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-server-edition/master/fullstaq-ruby.asc'
+      gpgkey 'https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-server-edition/main/fullstaq-ruby.asc'
       repo_gpgcheck true
       sslverify true
       only_if { node['ruby-provider'] == 'fullstaq' }


### PR DESCRIPTION
the url to the fullstaq key is wrong and it throws an 404 during setup run .. the right one is https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-server-edition/main/fullstaq-ruby.asc