### PR TITLE
Allow CORS to /packs

### DIFF
--- a/templates/default/appserver.apache2.passenger.conf.erb
+++ b/templates/default/appserver.apache2.passenger.conf.erb
@@ -47,7 +47,17 @@ Header always unset "X-Powered-By"
     Header set Access-Control-Allow-Methods "GET, PUT, POST, DELETE"
     Header set Access-Control-Expose-Headers "ETag"
     Header set X-Content-Type-Options "nosniff"
-    </Location>
+  </Location>
+
+  <Location "/packs/">
+    ExpiresActive on
+
+    Header set Cache-Control "public"
+    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Methods "GET, PUT, POST, DELETE"
+    Header set Access-Control-Expose-Headers "ETag"
+    Header set X-Content-Type-Options "nosniff"
+  </Location>
 
 <% if @appserver_config[:max_pool_size] -%>
   PassengerMaxPoolSize <%= @appserver_config[:max_pool_size] %>
@@ -139,6 +149,16 @@ SSLStaplingCache "shmcb:logs/stapling-cache(150000)"
   KeepAliveTimeout <%= @out[:keepalive_timeout] || '15' %>
 
   <Location "/assets/">
+    ExpiresActive on
+
+    Header set Cache-Control "public"
+    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Methods "GET, PUT, POST, DELETE"
+    Header set Access-Control-Expose-Headers "ETag"
+    Header set X-Content-Type-Options "nosniff"
+  </Location>
+
+  <Location "/packs/">
     ExpiresActive on
 
     Header set Cache-Control "public"

--- a/templates/default/appserver.apache2.upstream.conf.erb
+++ b/templates/default/appserver.apache2.upstream.conf.erb
@@ -47,6 +47,16 @@ Listen <%= @out[:port] %>
     Header set X-Content-Type-Options "nosniff"
   </Location>
 
+  <Location "/packs/">
+    ExpiresActive on
+
+    Header set Cache-Control "public"
+    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Methods "GET, PUT, POST, DELETE"
+    Header set Access-Control-Expose-Headers "ETag"
+    Header set X-Content-Type-Options "nosniff"
+  </Location>
+
   RewriteEngine on
 
   <Proxy balancer://<%= upstream %>>
@@ -126,6 +136,16 @@ SSLStaplingCache "shmcb:logs/stapling-cache(150000)"
   KeepAliveTimeout <%= @out[:keepalive_timeout] || '15' %>
 
   <Location "/assets/">
+    ExpiresActive on
+
+    Header set Cache-Control "public"
+    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Methods "GET, PUT, POST, DELETE"
+    Header set Access-Control-Expose-Headers "ETag"
+    Header set X-Content-Type-Options "nosniff"
+  </Location>
+
+  <Location "/packs/">
     ExpiresActive on
 
     Header set Cache-Control "public"

--- a/templates/default/appserver.nginx.conf.erb
+++ b/templates/default/appserver.nginx.conf.erb
@@ -48,6 +48,16 @@ server {
     add_header X-Content-Type-Options nosniff;
   }
 
+  location ^~ /packs/ {
+    gzip_static on;
+    expires max;
+    add_header Cache-Control public;
+    add_header Access-Control-Allow-Origin "$http_origin";
+    add_header Access-Control-Allow-Methods 'GET, PUT, POST, DELETE';
+    add_header Access-Control-Expose-Headers ETag;
+    add_header X-Content-Type-Options nosniff;
+  }
+
   location @<%= @name %> {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
@@ -138,6 +148,16 @@ server {
   }
 
   location ^~ /assets/ {
+    gzip_static on;
+    expires max;
+    add_header Cache-Control public;
+    add_header Access-Control-Allow-Origin "$http_origin";
+    add_header Access-Control-Allow-Methods 'GET, PUT, POST, DELETE';
+    add_header Access-Control-Expose-Headers ETag;
+    add_header X-Content-Type-Options nosniff;
+  }
+
+  location ^~ /packs/ {
     gzip_static on;
     expires max;
     add_header Cache-Control public;


### PR DESCRIPTION
Allow CORS request to `/packs` as same as `/assets`.

ref: #248