### PR TITLE
Run `monit reload` only once, after `configure hook`

### DIFF
--- a/libraries/drivers_appserver_base.rb
+++ b/libraries/drivers_appserver_base.rb
@@ -47,8 +47,6 @@ module Drivers
           source 'appserver.monitrc.erb'
           variables opts
         end
-
-        context.execute 'monit reload'
       end
 
       def restart_monit

--- a/libraries/drivers_worker_base.rb
+++ b/libraries/drivers_worker_base.rb
@@ -25,8 +25,6 @@ module Drivers
           cookbook opts[:source_cookbook].to_s
           variables opts
         end
-
-        context.execute 'monit reload'
       end
 
       def worker_monit_template_cookbook

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -35,4 +35,8 @@ every_enabled_application do |application|
   webserver = Drivers::Webserver::Factory.build(self, application)
 
   fire_hook(:configure, items: databases + [source, framework, appserver, worker, webserver])
+
+  execute 'monit reload' do
+    only_if 'which monit'
+  end
 end

--- a/spec/unit/recipes/configure_spec.rb
+++ b/spec/unit/recipes/configure_spec.rb
@@ -24,9 +24,11 @@ describe 'opsworks_ruby::configure' do
   let(:chef_run_rhel) do
     chef_runner_rhel.converge(described_recipe)
   end
+  let(:monit_installed) { false }
   before do
     stub_search(:aws_opsworks_app, '*:*').and_return([aws_opsworks_app])
     stub_search(:aws_opsworks_rds_db_instance, '*:*').and_return([aws_opsworks_rds_db_instance])
+    stub_command('which monit').and_return(monit_installed)
   end
 
   context 'context savvy' do
@@ -65,6 +67,8 @@ describe 'opsworks_ruby::configure' do
   end
 
   context 'Postgresql + Git + Unicorn + Nginx + Rails + Sidekiq' do
+    let(:monit_installed) { true }
+
     it 'creates proper database.yml template with connection options' do
       db_config = Drivers::Db::Postgresql.new(chef_run, aws_opsworks_app, rds: aws_opsworks_rds_db_instance).out
       expect(db_config[:adapter]).to eq 'postgresql'
@@ -502,6 +506,7 @@ describe 'opsworks_ruby::configure' do
         solo_node.set['deploy'] = deploy
       end.converge(described_recipe)
     end
+    let(:monit_installed) { true }
 
     before do
       stub_search(:aws_opsworks_rds_db_instance, '*:*').and_return([aws_opsworks_rds_db_instance(engine: 'mysql')])
@@ -1023,6 +1028,7 @@ describe 'opsworks_ruby::configure' do
         solo_node.set['nginx'] = node['nginx']
       end.converge(described_recipe)
     end
+    let(:monit_installed) { true }
 
     before do
       stub_search(:aws_opsworks_app, '*:*').and_return([aws_opsworks_app(data_sources: [])])

--- a/spec/unit/recipes/deploy_spec.rb
+++ b/spec/unit/recipes/deploy_spec.rb
@@ -20,9 +20,11 @@ describe 'opsworks_ruby::deploy' do
   let(:chef_run_rhel) do
     chef_runner_rhel.converge(described_recipe)
   end
+  let(:monit_installed) { false }
   before do
     stub_search(:aws_opsworks_app, '*:*').and_return([aws_opsworks_app])
     stub_search(:aws_opsworks_rds_db_instance, '*:*').and_return([aws_opsworks_rds_db_instance])
+    stub_command('which monit').and_return(monit_installed)
   end
 
   it 'includes recipes' do
@@ -69,6 +71,8 @@ describe 'opsworks_ruby::deploy' do
   end
 
   context 'Postgresql + Git + Unicorn + Nginx + Sidekiq' do
+    let(:monit_installed) { true }
+
     it 'creates git wrapper script' do
       expect(chef_run).to create_template('/tmp/ssh-git-wrapper.sh')
     end
@@ -204,6 +208,7 @@ describe 'opsworks_ruby::deploy' do
         solo_node.set['deploy'] = deploy
       end
     end
+    let(:monit_installed) { true }
     let(:tmpdir) { '/tmp/opsworks_ruby' }
 
     before do
@@ -289,6 +294,7 @@ describe 'opsworks_ruby::deploy' do
         solo_node.set['deploy'] = deploy
       end
     end
+    let(:monit_installed) { true }
     let(:tmpdir) { '/tmp/opsworks_ruby' }
 
     before do


### PR DESCRIPTION
In order to avoid running `monit reload` multiple times in a row, I changed it to run `monit reload` only once after running the `configure` hook.

ref: #251