### PR TITLE
feat(worker): worker option to use dot env

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -57,6 +57,7 @@ suites:
             extra_config_ssl: true
           worker:
             adapter: "sidekiq"
+            dot_env: true
             config:
               concurency: 5
               verbose: true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -170,6 +170,7 @@ default['defaults']['framework']['envs_in_console'] = false
 default['defaults']['worker']['adapter'] = 'null'
 default['defaults']['worker']['process_count'] = 2
 default['defaults']['worker']['syslog'] = true
+default['defaults']['worker']['dot_env'] = false
 
 default['monit']['basedir'] = if platform?('centos', 'redhat', 'fedora', 'amazon')
                                 '/etc/monit.d'

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -678,6 +678,11 @@ Worker configuration. Currently sidekiq, delayed_job, resque, shoryuken, good_jo
     - **Default** `opsworks_ruby`
     - The name of the cookbook from which the worker monit template(s) will be drawn.
 
+- `app['worker']['dot_env']`
+    - **Supported values:** `true`, `false`
+    - **Default:** `false`
+    - Creates a `.env` file with all pre-configured environment variables. Useful for gems like [dotenv](https://github.com/bkeepers/dotenv)
+
 #### sidekiq
 
 - `app['worker']['config']`

--- a/libraries/drivers_appserver_base.rb
+++ b/libraries/drivers_appserver_base.rb
@@ -129,26 +129,18 @@ module Drivers
         return unless raw_out[:application_yml]
 
         append_to_overwritable_defaults('symlinks', 'config/application.yml' => 'config/application.yml')
-        env_config(source_file: 'config/application.yml', destination_file: 'config/application.yml')
+        env_config(
+          source_file: 'config/application.yml',
+          destination_file: 'config/application.yml',
+          environment: environment
+        )
       end
 
       def setup_dot_env
         return unless raw_out[:dot_env]
 
         append_to_overwritable_defaults('symlinks', 'dot_env' => '.env')
-        env_config(source_file: 'dot_env', destination_file: 'dot_env')
-      end
-
-      def env_config(options = { source_file: nil, destination_file: nil })
-        deploy_to = deploy_dir(app)
-        env = environment
-
-        context.template File.join(deploy_to, 'shared', options[:destination_file]) do
-          owner node['deployer']['user']
-          group www_group
-          source "#{File.basename(options[:source_file])}.erb"
-          variables environment: env
-        end
+        env_config(source_file: 'dot_env', destination_file: 'dot_env', environment: environment)
       end
 
       def environment

--- a/libraries/drivers_worker_base.rb
+++ b/libraries/drivers_worker_base.rb
@@ -22,6 +22,7 @@ module Drivers
 
       # Adds or updates the monit configs for the worker and notifies monit to
       # reload the configuration.
+      # rubocop:disable Metrics/AbcSize
       def add_worker_monit
         opts = {
           adapter: adapter,
@@ -43,6 +44,7 @@ module Drivers
           notifies :run, 'execute[monit reload]', :immediately
         end
       end
+      # rubocop:enable Metrics/AbcSize
 
       def embed_environment_in_monit?
         !raw_out[:dot_env]
@@ -52,19 +54,7 @@ module Drivers
         return unless raw_out[:dot_env]
 
         append_to_overwritable_defaults('symlinks', 'dot_env' => '.env')
-        env_config(source_file: 'dot_env', destination_file: 'dot_env')
-      end
-
-      def env_config(options = { source_file: nil, destination_file: nil })
-        deploy_to = deploy_dir(app)
-        env = environment
-
-        context.template File.join(deploy_to, 'shared', options[:destination_file]) do
-          owner node['deployer']['user']
-          group www_group
-          source "#{File.basename(options[:source_file])}.erb"
-          variables environment: env
-        end
+        env_config(source_file: 'dot_env', destination_file: 'dot_env', environment: environment)
       end
 
       def worker_monit_template_cookbook

--- a/libraries/drivers_worker_shoryuken.rb
+++ b/libraries/drivers_worker_shoryuken.rb
@@ -14,6 +14,7 @@ module Drivers
       end
 
       def before_deploy
+        super
         quiet_shoryuken
       end
 

--- a/libraries/drivers_worker_sidekiq.rb
+++ b/libraries/drivers_worker_sidekiq.rb
@@ -14,6 +14,7 @@ module Drivers
       end
 
       def before_deploy
+        super
         quiet_sidekiq
       end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -146,3 +146,15 @@ def append_to_overwritable_defaults(field, options) # rubocop:disable Metrics/Ab
   end
   node.default['deploy'][app['shortname']]['global'][field].merge!(options)
 end
+
+def env_config(options = { source_file: nil, destination_file: nil, environment: {} })
+  deploy_to = deploy_dir(app)
+  env = environment
+
+  context.template File.join(deploy_to, 'shared', options[:destination_file]) do
+    owner node['deployer']['user']
+    group www_group
+    source "#{File.basename(options[:source_file])}.erb"
+    variables environment: env
+  end
+end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -149,7 +149,7 @@ end
 
 def env_config(options = { source_file: nil, destination_file: nil, environment: {} })
   deploy_to = deploy_dir(app)
-  env = environment
+  env = options[:environment]
 
   context.template File.join(deploy_to, 'shared', options[:destination_file]) do
     owner node['deployer']['user']

--- a/test/integration/all_options/serverspec/all_options_spec.rb
+++ b/test/integration/all_options/serverspec/all_options_spec.rb
@@ -126,13 +126,13 @@ describe 'opsworks_ruby::configure' do
       its(:content) { should include 'group sidekiq_dummy_project_group' }
       its(:content) { should include 'check process sidekiq_dummy_project-1' }
       its(:content) do
-        should include 'RAILS_ENV="staging" HOME="/home/deploy" USER="deploy" ' \
+        should include 'RAILS_ENV="staging" ' \
                        'bundle exec sidekiq -C /srv/www/dummy_project/shared/config/sidekiq_1.yml'
       end
       its(:content) { should include 'logger -t sidekiq-dummy_project-1' }
       its(:content) { should include 'check process sidekiq_dummy_project-2' }
       its(:content) do
-        should include 'RAILS_ENV="staging" HOME="/home/deploy" USER="deploy" ' \
+        should include 'RAILS_ENV="staging" ' \
                        'bundle exec sidekiq -C /srv/www/dummy_project/shared/config/sidekiq_2.yml'
       end
       its(:content) { should include 'logger -t sidekiq-dummy_project-2' }


### PR DESCRIPTION
When the monit start script exceeds 4kb monit (any version under 5.27.0) isn't able to monitor the process. 
reference to the [issue](https://bitbucket.org/tildeslash/monit/issues/851) on monit which has to do with the ps command buffer.
reference to the [changelog](https://bitbucket.org/tildeslash/monit/src/release-5-27-0/CHANGES) that includes this fix.

My servers use an older version of monit, and amazon linux has even older versions. This Pr allows workers to use dot env rather than storing all of them in the monit file, just like the app server already does.